### PR TITLE
Refactor Context & Data Sequences to Collections

### DIFF
--- a/semantiva/context_operations/context_types.py
+++ b/semantiva/context_operations/context_types.py
@@ -98,22 +98,22 @@ class ContextType:
         return f"{self.__class__.__name__}(context={self._context_container})"
 
 
-class ContextSequenceType(ContextType):
+class ContextCollectionType(ContextType):
     """
     A specialized context type that stores and manages multiple `ContextType` instances.
 
     This class extends `ContextType` but internally keeps a list of separate contexts.
-    Each item in the sequence is a `ContextType`, enabling parallel iteration with
-    DataSequence subclasses that contain multiple data items.
+    Each item in the collection is a `ContextType`, enabling parallel iteration with
+    DataC subclasses that contain multiple data items.
     """
 
     def __init__(self, context_list: Optional[List[ContextType]] = None):
         """
-        Initialize a `ContextSequenceType` with an optional list of `ContextType` instances.
+        Initialize a `ContextCollectonType` with an optional list of `ContextType` instances.
 
         Args:
             context_list (Optional[List[ContextType]]): A list of `ContextType` objects
-                                                       to initialize the sequence. If None,
+                                                       to initialize the collecton. If None,
                                                        an empty list is used.
         """
         # We won't use _context_container from the base for storing items; we store them in a list.
@@ -127,13 +127,13 @@ class ContextSequenceType(ContextType):
         Return an iterator over the stored `ContextType` instances.
 
         Yields:
-            ContextType: Each context in the sequence.
+            ContextType: Each context in the collecton.
         """
         return iter(self._context_list)
 
     def __len__(self) -> int:
         """
-        Return the number of context elements in this sequence.
+        Return the number of context elements in this collecton.
 
         Returns:
             int: The length of the internal list of `ContextType`s.
@@ -142,7 +142,7 @@ class ContextSequenceType(ContextType):
 
     def append(self, item: ContextType) -> None:
         """
-        Append a `ContextType` object to the end of this sequence.
+        Append a `ContextType` object to the end of this collecton.
 
         Args:
             item (ContextType): The context to be appended.
@@ -156,7 +156,7 @@ class ContextSequenceType(ContextType):
 
     def __getitem__(self, index: int) -> ContextType:
         """
-        Retrieve a specific `ContextType` from the sequence by index.
+        Retrieve a specific `ContextType` from the collecton by index.
 
         Args:
             index (int): The index of the desired context.
@@ -168,9 +168,9 @@ class ContextSequenceType(ContextType):
 
     def __str__(self) -> str:
         """
-        Return a string representation of the sequence, showing its length.
+        Return a string representation of the collecton, showing its length.
 
         Returns:
-            str: A descriptive string of this sequence object.
+            str: A descriptive string of this collecton object.
         """
         return f"{self.__class__.__name__}(length={len(self._context_list)})"

--- a/semantiva/specializations/image/image_data_types.py
+++ b/semantiva/specializations/image/image_data_types.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import Iterator, Optional
-from semantiva.data_types import BaseDataType, DataSequence
+from semantiva.data_types import BaseDataType, DataCollectionType
 
 
 class ImageDataType(BaseDataType[np.ndarray]):
@@ -48,9 +48,9 @@ class ImageDataType(BaseDataType[np.ndarray]):
         return data
 
 
-class ImageStackDataType(DataSequence[ImageDataType, np.ndarray]):
+class ImageStackDataType(DataCollectionType[ImageDataType, np.ndarray]):
     """
-    A class representing a stack of image data, derived from DataSequence.
+    A class representing a stack of image data, derived from DataCollecton.
 
     This class is designed to handle multi-dimensional image data (e.g., a stack of 2D images)
     and provides validation to ensure that the input is a NumPy array.

--- a/tests/test_image_io.py
+++ b/tests/test_image_io.py
@@ -103,7 +103,7 @@ def test_image_stack_iterator():
     # Create an ImageStackArrayDataType instance
     image_stack = ImageStackDataType(stack_data)
 
-    assert image_stack.sequence_base_type() == ImageDataType
+    assert image_stack.collection_base_type() == ImageDataType
 
     # Collect all elements from the iterator
     images = list(iter(image_stack))  # Equivalent to: [img for img in image_stack]

--- a/tests/test_image_pipeline_and_task.py
+++ b/tests/test_image_pipeline_and_task.py
@@ -93,9 +93,9 @@ def test_pipeline_task(random_image, another_random_image):
 
 def test_pipeline_slicing(random_image_stack, random_image, another_random_image):
     """
-    Tests the pipeline's ability to correctly slice a DataSequence when required.
+    Tests the pipeline's ability to correctly slice a DataCollecton when required.
 
-    - The input (`ImageStackDataType`) contains a sequence of `ImageDataType` elements.
+    - The input (`ImageStackDataType`) contains a collecton of `ImageDataType` elements.
     - The pipeline processes each `ImageDataType` individually via slicing.
     - The final output should remain an `ImageStackDataType` with the same number of images.
     """

--- a/tests/test_pipeline_slicing.py
+++ b/tests/test_pipeline_slicing.py
@@ -1,5 +1,8 @@
 import pytest
-from semantiva.context_operations.context_types import ContextType, ContextSequenceType
+from semantiva.context_operations.context_types import (
+    ContextType,
+    ContextCollectionType,
+)
 from semantiva.specializations.image.image_loaders_savers_generators import (
     ImageDataRandomGenerator,
     ImageStackRandomGenerator,
@@ -53,11 +56,11 @@ def random_context():
 
 
 @pytest.fixture
-def random_context_sequence():
+def random_context_collecton():
     """
-    Pytest fixture providing a ContextSequenceType with 5 distinct context items.
+    Pytest fixture providing a ContextCollectonType with 5 distinct context items.
     """
-    return ContextSequenceType([ContextType({"param": i}) for i in range(5)])
+    return ContextCollectionType([ContextType({"param": i}) for i in range(5)])
 
 
 def test_pipeline_slicing_with_single_context(
@@ -95,11 +98,11 @@ def test_pipeline_slicing_with_single_context(
     ), "Context should remain a ContextType"
 
 
-def test_pipeline_slicing_with_context_sequence(
-    random_image_stack, random_image, another_random_image, random_context_sequence
+def test_pipeline_slicing_with_context_collecton(
+    random_image_stack, random_image, another_random_image, random_context_collecton
 ):
     """
-    Tests slicing when using a ContextSequenceType.
+    Tests slicing when using a ContextCollectonType.
 
     - The `ImageStackDataType` is sliced into `ImageDataType` items.
     - A **corresponding** `ContextType` is used for each sliced item.
@@ -120,7 +123,7 @@ def test_pipeline_slicing_with_context_sequence(
     pipeline = Pipeline(node_configurations)
 
     output_data, output_context = pipeline.process(
-        random_image_stack, random_context_sequence
+        random_image_stack, random_context_collecton
     )
 
     assert isinstance(
@@ -128,9 +131,9 @@ def test_pipeline_slicing_with_context_sequence(
     ), "Output should be an ImageStackDataType"
     assert len(output_data) == 5, "ImageStackDataType should retain 5 images"
     assert isinstance(
-        output_context, ContextSequenceType
-    ), "Context should remain a ContextSequenceType"
-    assert len(output_context) == 5, "ContextSequenceType should retain 5 items"
+        output_context, ContextCollectionType
+    ), "Context should remain a ContextCollectonType"
+    assert len(output_context) == 5, "ContextCollectonType should retain 5 items"
 
 
 def test_pipeline_without_slicing(random_image, another_random_image, random_context):


### PR DESCRIPTION
- Renamed `DataSequence` → `DataCollectionType` to better represent generic collections of data.
- Renamed `ContextSequenceType` → `ContextCollectionType` for consistency with `DataCollectionType`.
- Refactored **method names** (`sequence_base_type` → `collection_base_type`) for consistency.