### PR TITLE
Improve component loader

### DIFF
--- a/semantiva/component_loader/component_loader.py
+++ b/semantiva/component_loader/component_loader.py
@@ -28,9 +28,23 @@ class ComponentLoader:
             cls._registered_paths.add(Path(path))
 
     @classmethod
+    def register_modules(cls, modules: str | List[str]):
+        """Register a module or a list of modules"""
+        if isinstance(modules, str):
+            modules = [modules]
+
+        for module in modules:
+            cls._registered_modules.add(module)
+
+    @classmethod
     def get_registered_paths(cls) -> Set[Path]:
         """Get list of registered paths"""
         return cls._registered_paths
+
+    @classmethod
+    def get_registered_modules(cls) -> Set[str]:
+        """Get list of registered modules"""
+        return cls._registered_modules
 
     @classmethod
     def get_class(cls, class_name: str):
@@ -54,11 +68,14 @@ class ComponentLoader:
     @classmethod
     def _get_class_from_module(cls, module_name: str, class_name: str):
         """Lookup in registered modules for the class and
-        return its type."""
+        return its type. If module is not found, return None."""
 
-        module = import_module(module_name)
-        class_type = getattr(module, class_name, None)
-        return class_type
+        try:
+            module = import_module(module_name)
+            class_type = getattr(module, class_name, None)
+            return class_type
+        except ModuleNotFoundError:
+            return None
 
     @classmethod
     def _get_class_from_file(cls, file_path: Path, class_name: str):

--- a/tests/test_component_loader.py
+++ b/tests/test_component_loader.py
@@ -26,6 +26,25 @@ def test_register_paths(mock_is_file, loader):
     assert registered_paths == expected_paths
 
 
+def test_register_modules(loader):
+    """Test if register_modules correctly adds modules."""
+
+    loader._registered_modules = set()  # Reset registered modules
+
+    loader.register_modules(
+        [
+            "new_module.image_algo",
+            "new_module.image_probes",
+        ]
+    )
+    registered_modules = loader.get_registered_modules()
+
+    expected_modules = {"new_module.image_algo", "new_module.image_probes"}
+    assert registered_modules == expected_modules
+
+    loader.initialize_default_modules()  # Reset registered modules
+
+
 @patch("pathlib.Path.is_file", return_value=True)
 def test_get_class(mock_is_file, loader):
     """Test if get_class correctly loads a class from registered paths."""

--- a/tests/test_component_loader.py
+++ b/tests/test_component_loader.py
@@ -18,13 +18,12 @@ def default_context_operation():
 @patch("pathlib.Path.is_file", return_value=True)
 def test_register_paths(mock_is_file, loader):
     """Test if register_paths correctly adds paths."""
-    loader._registered_paths = set()  # Clear out default paths
+
     loader.register_paths(["new_path/image_algo.py", "new_path/image_probes.py"])
     registered_paths = loader.get_registered_paths()
 
     expected_paths = {Path("new_path/image_algo.py"), Path("new_path/image_probes.py")}
     assert registered_paths == expected_paths
-    loader.initialize_default_paths()  # Reset default paths
 
 
 @patch("pathlib.Path.is_file", return_value=True)


### PR DESCRIPTION
### Changes

- Added `_registered_modules` set of strings, where a set of modules is registered by default. It is mainly used to check on internal modules of the framework. When looking up for a class, the component loader will first check the registered modules, if not found, then it will go for the registered file paths.

This improvement was meant to gain efficiency, since importing modules dynamically from a file path is way more complicated.