### PR TITLE
Refactor Data Slicing Strategies & Improve Context Handling

### DIFF
--- a/semantiva/payload_operations/payload_operations.py
+++ b/semantiva/payload_operations/payload_operations.py
@@ -53,4 +53,7 @@ class PayloadOperation(ContextObserver, ABC):
             NotImplementedError: If the `_process` method is not implemented in a subclass.
         """
         context_ = ContextType(context) if isinstance(context, dict) else context
+        assert isinstance(
+            context_, ContextType
+        ), f"Context must be a dictionary of an instance of `ContextType`. Got {type(context)}"
         return self._process(data, context_)

--- a/tests/test_pipeline_slicing.py
+++ b/tests/test_pipeline_slicing.py
@@ -135,21 +135,37 @@ def test_pipeline_slicing_with_context_collection(
 
     node_configurations = [
         {
-            "operation": ImageAddition,
-            "parameters": {"image_to_add": random_image},
+            "operation": ImageAddition,  # Adds a specified image to each slice of the input data
+            "parameters": {
+                "image_to_add": random_image
+            },  # Image to be added to each slice
         },
         {
-            "operation": ImageSubtraction,
-            "parameters": {"image_to_subtract": another_random_image},
+            "operation": ImageSubtraction,  # Subtracts a specified image from each slice of the input data
+            "parameters": {
+                "image_to_subtract": another_random_image
+            },  # Image to subtract
+        },
+        {
+            "operation": BasicImageProbe,  # Probe operation to extract and store data
+            "context_keyword": "mock_keyword",  # Stores probe results under this keyword in the context
+            "parameters": {},  # No extra parameters required (can be omitted)
+        },
+        {
+            "operation": BasicImageProbe,  # Probe operation to collect results
+            "parameters": {},  # No extra parameters required (can be omitted)
+            # No `context_keyword`, making this node a ProbeCollectorNode (results stored internally)
         },
     ]
-
     pipeline = Pipeline(node_configurations)
 
     output_data, output_context = pipeline.process(
         random_image_stack, random_context_collection
     )
 
+    assert len(pipeline.get_probe_results()["Node 4/BasicImageProbe"][0]) == len(
+        output_data
+    )
     assert isinstance(
         output_data, ImageStackDataType
     ), "Output should be an ImageStackDataType"


### PR DESCRIPTION
This PR refactors data slicing strategies for data nodes.

#### **Case 1: (Single Data, Single Context)**
 A single data object is processed with a single context; no slicing required.  

#### **Case 2: (DataCollection, Single Context)**  
Each data item is processed using the same context; new context values are aggregated in a list.  

  - **`AlgorithmNode`** → Processes each data slice with the same context. If the operation creates new context values, they are stored as a **list under the corresponding key**.  
  - **`ProbeContextInjectorNode`** → Runs the probe on each data slice, collecting results into a **list** and storing it under the defined `context_keyword`.  
  - **`ProbeResultCollectorNode`** → Executes the probe on each data slice and **aggregates results into a list** stored in `_probed_data`.  

#### **Case 3: (DataCollection, ContextCollection)**  
Each data item is paired with its corresponding context item; raises `ValueError` if sizes mismatch.  

  - **`AlgorithmNode`** → Ensures a **one-to-one mapping** between data and context slices. Each data item is processed with its respective context, and context updates remain **individual** (not lists).  
  - **`ProbeContextInjectorNode`** → Runs the probe on each data slice with its corresponding context, **storing each result individually** under `context_keyword`.  
  - **`ProbeResultCollectorNode`** → Executes the probe for each data-context pair and **stores results individually** in `_probed_data`.  