### PR TITLE
Refactor ContextCollectionType: consistency between  global and item levels

### DIFF
--- a/semantiva/context_operations/context_types.py
+++ b/semantiva/context_operations/context_types.py
@@ -1,4 +1,5 @@
 from typing import Any, List, Optional, Iterator, Union, Dict, Tuple
+from ..logger import Logger
 
 
 class ContextType:
@@ -13,7 +14,9 @@ class ContextType:
                                    the context data.
     """
 
-    def __init__(self, context_dict: Optional[Dict] = None):
+    def __init__(
+        self, context_dict: Optional[Dict] = None, logger: Optional[Logger] = None
+    ):
         """
         Initialize a ContextType with an optional context_dict.
 
@@ -22,6 +25,10 @@ class ContextType:
                                                     Defaults to None, resulting in an empty context.
         """
         self._context_container = {} if context_dict is None else context_dict
+        if logger is not None:
+            self.logger = logger
+        else:
+            self.logger = Logger()
 
     def get_value(self, key: str) -> Any:
         """
@@ -97,6 +104,11 @@ class ContextType:
     def __str__(self) -> str:
         return f"{self.__class__.__name__}(context={self._context_container})"
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ContextType):
+            return False
+        return self._context_container == other._context_container
+
 
 class ContextCollectionType(ContextType):
     """
@@ -107,17 +119,49 @@ class ContextCollectionType(ContextType):
     DataC subclasses that contain multiple data items.
     """
 
-    def __init__(self, context_list: Optional[List[ContextType]] = None):
+    def __init__(
+        self,
+        collection_context: Optional[Union[ContextType, Dict]] = None,
+        context_list: Optional[List[ContextType]] = None,
+        logger: Optional[Logger] = None,
+    ):
         """
-        Initialize a `ContextCollectionType` with an optional list of `ContextType` instances.
+        Initialize a ContextCollectionType instance that manages multiple ContextType items.
+
+        In this specialized context, two separate containers are maintained:
+        - The collection context (inherited from ContextType) holds global or shared key-value pairs.
+        - The individual context list (_context_list) holds multiple ContextType instances, allowing
+            for parallel storage and iteration of separate contexts.
+
+        The collection_context parameter can be provided in two forms:
+        • As a dictionary, which will be used directly.
+        • As a ContextType, in which case its internal _context_container is extracted.
+        If collection_context is None, an empty dictionary will be used.
 
         Args:
-            context_list (Optional[List[ContextType]]): A list of `ContextType` objects
-                                                       to initialize the collection. If None,
-                                                       an empty list is used.
+            collection_context (Optional[Union[ContextType, Dict]]): Global context data, either as a
+                ContextType instance or a dictionary. Defaults to None.
+            context_list (Optional[List[ContextType]]): A list of individual ContextType instances.
+                If None, an empty list is initialized.
+            logger (Optional[Logger]): A Logger instance used for logging within the context.
+                If None, a default Logger is instantiated.
         """
-        # We won't use _context_container from the base for storing items; we store them in a list.
-        super().__init__()
+        # Determine the base context container:
+        # - If no collection_context is provided, initialize with an empty dict.
+        # - If collection_context is a dict, use it as-is.
+        # - If it's a ContextType, extract its _context_container.
+        collection_context_ = (
+            {}
+            if collection_context is None
+            else (
+                collection_context
+                if isinstance(collection_context, dict)
+                else collection_context._context_container
+            )
+        )
+        # Initialize the base ContextType with the determined context container and logger.
+        super().__init__(context_dict=collection_context_, logger=logger)
+        # Initialize the list to hold individual ContextType instances.
         self._context_list: List[ContextType] = (
             context_list if context_list is not None else []
         )
@@ -155,22 +199,269 @@ class ContextCollectionType(ContextType):
         self._context_list.append(item)
 
     def __getitem__(self, index: int) -> ContextType:
-        """
-        Retrieve a specific `ContextType` from the collection by index.
+        return self.get_item(index)
 
-        Args:
-            index (int): The index of the desired context.
-
-        Returns:
-            ContextType: The context at the specified index.
-        """
-        return self._context_list[index]
+    ###################### Overriden ContextType methods tailored for collections  ######################
 
     def __str__(self) -> str:
         """
-        Return a string representation of the collection, showing its length.
+        Return a string representation of the collection, showing its length,
+        global context, and individual contexts.
 
         Returns:
             str: A descriptive string of this collection object.
         """
-        return f"{self.__class__.__name__}(length={len(self._context_list)})"
+        global_str = f"global_context={self._context_container}"
+        individual_str = (
+            f"individual_contexts={[str(ctx) for ctx in self._context_list]}"
+        )
+        return f"{self.__class__.__name__}(length={len(self._context_list)}, {global_str}, {individual_str})"
+
+    def get_item(self, index: int) -> ContextType:
+        """
+        Retrieve and combine an individual ContextType instance with the global collection context.
+
+        This method fetches the ContextType at the specified index from the internal
+        context list (_context_list) and merges its key-value pairs with those from the
+        global collection context (_context_container).
+
+        In the event that the same key exists in both contexts an exception is raised
+        because this case indicates a fragile data structure design.
+
+        Args:
+            index (int): The index of the desired individual context.
+
+        Returns:
+            ContextType: A new ContextType instance representing the merged context.
+                Keys from the global context override those in the individual context.
+        """
+        item_context = self._context_list[index]
+
+        # Check for overlapping keys between the individual context and the global collection.
+        # If an overlap is found, log a warning and proceed with the global value.
+        for key in item_context.keys():
+            if key in self._context_container:
+                raise ValueError(
+                    f"Key '{key}' is present in both the global collection and the individual context. "
+                    "This fragile data structure design prevents proper merging.\n="
+                    "Consider renaming the key or use a ContextOperation to improve the data structure."
+                )
+
+        # Merge dictionaries: keys from the global collection (_context_container)
+        # take precedence over those in the individual context.
+        combined_context = ContextType(
+            {**self._context_container, **item_context._context_container}
+        )
+        return combined_context
+
+    def get_value(self, key: str) -> Any:
+        """
+        Retrieve a value from the context collection for the specified key.
+
+        This method searches for the specified key in both the global context
+        (_context_container) and the individual contexts (_context_list). It applies
+        the following rules:
+        - If the key is present only in the global context, return the corresponding value.
+        - If the key is present only in individual contexts, return a list of values,
+          one for each context (using None when the key is missing in a particular context).
+          If all individual contexts return None, then return None.
+        - If the key is present in both the global context and any individual context, raise a
+          ValueError because this overlap indicates a fragile data structure design.
+
+        Args:
+            key (str): The key for which to retrieve the value.
+
+        Returns:
+            Any: The value associated with the key. This may be a single value (from the global context),
+                a list of values (from individual contexts), or None if the key is not found.
+        """
+        in_global = key in self._context_container
+        # Always collect a list of values from individual contexts.
+        individual_values = [context.get_value(key) for context in self._context_list]
+
+        # If the key exists in both global and any individual context, raise an exception.
+        if in_global and any(value is not None for value in individual_values):
+            raise ValueError(
+                f"Key '{key}' is present in both the global collection and individual contexts. "
+                "This fragile data structure design prevents proper merging. "
+                "Consider renaming the key or using a ContextOperation to improve the data structure."
+            )
+
+        # Return the value from the global context if it exists.
+        if in_global:
+            return self._context_container.get(key)
+
+        # If any individual context provided a non-None value, return the list.
+        if any(value is not None for value in individual_values):
+            return individual_values
+
+        # If the key is not found anywhere, return None.
+        return None
+
+    def set_value(self, key: str, value: Any):
+        """
+        Set or update a value in the context collection.
+
+        This method applies the following rules:
+        - If the key is present in the collection (global) context, update its value and
+            remove the key from any individual contexts to avoid conflicts.
+        - If the key is present only in one or more individual contexts, update the value
+            in all individual contexts.
+        - If the key is not found in either the global or individual contexts, add it to the
+            global collection context.
+
+        Args:
+            key (str): The key associated with the value to update or set.
+            value (Any): The new value to assign to the key.
+        """
+        # If key exists in the global collection, update it.
+        if key in self._context_container:
+            self._context_container[key] = value
+
+        # If key exists in any individual context, update all of them.
+        elif key in self.keys():
+            for context in self._context_list:
+                context.set_value(key, value)
+        # Otherwise, add the key to the global context.
+        else:
+            self._context_container[key] = value
+
+    def set_item_value(self, index: int, key: str, value: Any):
+        """
+        Set or update the value of a single item.
+
+        - If the key is present in the global context, raise an exception.
+        - If the key is present in the individual context, update it.
+          If not present, simply set it.
+
+        Args:
+            index (int): The index of the individual context to update.
+            key (str): The key whose value is to be set.
+            value (Any): The new value to assign.
+
+        Raises:
+            ValueError: If the key exists in the global collection context.
+        """
+        if key in self._context_container:
+            raise ValueError(
+                f"Key '{key}' is present in the global collection and cannot be set on an individual item."
+            )
+
+        # Retrieve the target individual context.
+        target_context = self._context_list[index]
+        # Update or set the key-value pair in that context.
+        target_context.set_value(key, value)
+
+    def delete_value(self, key: str):
+        """
+        Remove a key-value pair from the context collection.
+
+        This method removes the specified key from both the collection (global) context
+        and any individual contexts held within the collection. It applies the following rules:
+        - If the key is present in the global collection context, remove it.
+        - If the key is present in any individual contexts, remove it from each of them.
+        - If the key is not found in either the global context or any individual contexts,
+            raise a KeyError.
+
+        Args:
+            key (str): The key to be removed from the context.
+
+        Raises:
+            KeyError: If the key is not found in the collection context or any individual contexts.
+        """
+        found = False
+
+        # Remove key from the global context if it exists.
+        if key in self._context_container:
+            del self._context_container[key]
+            found = True
+
+        # Remove key from each individual context if present.
+        for context in self._context_list:
+            if key in context.keys():
+                context.delete_value(key)
+                found = True
+
+        # If the key wasn't found anywhere, raise an error.
+        if not found:
+            raise KeyError(f"Key '{key}' not found in context.")
+
+    def clear(self):
+        """
+        Clear all key-value pairs from the context collection.
+
+        This method resets the global context (_context_container) to an empty dictionary and
+        clears all key-value pairs from each individual ContextType stored in the
+        internal context list (_context_list). This ensures that the entire ContextCollectionType
+        is reset to an empty state.
+        """
+        self._context_container.clear()
+        for context in self._context_list:
+            context.clear()
+
+    def keys(self) -> List[str]:
+        """
+        Retrieve all keys in the context collection.
+
+        This method collects keys from both the global context (_context_container)
+        and each individual context in (_context_list). If a key is found to be present
+        in both the global context and any individual context, a ValueError is raised,
+        as this indicates an ambiguous or fragile data structure design.
+
+        Returns:
+            list: A combined list of all keys present in either the global or individual contexts.
+        """
+        # Get keys from the global context.
+        global_keys = set(self._context_container.keys())
+
+        # Get all keys from individual contexts.
+        individual_keys = set()
+        for context in self._context_list:
+            individual_keys.update(context.keys())
+
+        # If a key appears in both, raise an exception.
+        conflict_keys = global_keys.intersection(individual_keys)
+        if conflict_keys:
+            raise ValueError(
+                f"Conflicting key(s) found in both global and individual contexts: {', '.join(conflict_keys)}. "
+                "This fragile data structure design prevents proper merging. "
+                "Consider renaming the key or using a ContextOperation to improve the data structure."
+            )
+
+        # Return the union of keys.
+        combined_keys = global_keys.union(individual_keys)
+        return list(combined_keys)
+
+    def values(self) -> List[Any]:
+        """
+        Retrieve all values in the context collection.
+
+        This method iterates over all keys obtained from the collection (both global and individual)
+        using self.keys(). For each key, it retrieves the associated value by calling self.get_value(key).
+
+        The retrieval rules are as follows:
+        - If the key is present only in the global context, its value is returned.
+        - If the key is present only in one or more individual contexts, a list of values from
+            all those individual contexts is returned.
+        - If a key exists in both contexts, a ValueError is raised (as enforced by self.get_value).
+
+        Returns:
+            List[Any]: A list of values corresponding to each key in the context collection.
+        """
+        return [self.get_value(key) for key in self.keys()]
+
+    def items(self) -> List[Tuple[str, Any]]:
+        """
+        Retrieve all key-value pairs in the context collection.
+
+        This method uses self.keys() to retrieve a combined list of keys from the global
+        context (_context_container) and all individual contexts (_context_list). For each key,
+        it then obtains the associated value via self.get_value(key), which applies the rules for
+        merging or conflict handling between the global and individual contexts.
+
+        Returns:
+            List[Tuple[str, Any]]: A list of (key, value) tuples for all keys present in the context.
+                                The values may be a single value or a list of values, depending on
+                                where the key is defined.
+        """
+        return [(key, self.get_value(key)) for key in self.keys()]

--- a/semantiva/logger/logger.py
+++ b/semantiva/logger/logger.py
@@ -61,16 +61,23 @@ class Logger:
             self.logger = logging.getLogger(name)
         else:
             self.logger = logger
+
+        # If the Logger class has not been initialized yet, set default values.
+        # This ensures that the default log level and console output are only set once.
         if not self._initialized:
             if level is None:
-                level = "INFO"
+                level = "INFO"  # Default log level is INFO if not specified
             if console_output is None:
-                console_output = True
-        if level:
+                console_output = True  # Enable console output by default
+
+        # Apply the provided or default log level and console output configuration.
+        if level is not None:
             self.set_verbose_level(level)
         if console_output is not None:
             self.set_console_output(console_output)
-        self._initialized = True
+
+        # Mark the Logger class as initialized.
+        type(self)._initialized = True
 
     def set_verbose_level(self, verbosity_level: str):
         """

--- a/tests/test_context_collection.py
+++ b/tests/test_context_collection.py
@@ -1,0 +1,134 @@
+import pytest
+from semantiva.context_operations.context_types import (
+    ContextType,
+    ContextCollectionType,
+)
+
+
+def test_empty_collection():
+    collection = ContextCollectionType(context_list=[])
+    assert len(collection) == 0
+    with pytest.raises(IndexError):
+        _ = collection[0]
+
+
+def test_collection_indexing_and_iteration():
+    # Create two individual contexts with unique keys.
+    ctx1 = ContextType({"key1": "value1"})
+    ctx2 = ContextType({"key2": "value2"})
+    collection = ContextCollectionType(context_list=[ctx1, ctx2])
+
+    # Since the global context is empty, the merged view should equal the individual context.
+    merged1 = collection[0]
+    merged2 = collection[1]
+    assert merged1.get_value("key1") == "value1"
+    assert merged2.get_value("key2") == "value2"
+
+    # Test iteration over the collection.
+    items = [item for item in collection]
+    assert len(items) == 2
+
+
+def test_collection_with_global_context():
+    # Define a global context and an individual context with non-overlapping keys.
+    global_context = {"global_key": "global_value"}
+    item_context = ContextType({"item_key": "item_value"})
+    collection = ContextCollectionType(
+        collection_context=global_context, context_list=[item_context]
+    )
+
+    merged = collection[0]
+    # Global keys should be available alongside the individual context keys.
+    assert merged.get_value("global_key") == "global_value"
+    assert merged.get_value("item_key") == "item_value"
+
+
+def test_overlapping_keys_raise_error():
+    # Define a global context and an individual context with an overlapping key.
+    global_context = {"overlap": "global_value"}
+    item_context = ContextType({"overlap": "item_value", "other": "value"})
+    collection = ContextCollectionType(
+        collection_context=global_context, context_list=[item_context]
+    )
+
+    with pytest.raises(ValueError):
+        _ = collection.get_item(0)
+
+
+def test_append_and_type_validation():
+    ctx1 = ContextType({"a": 1})
+    collection = ContextCollectionType(context_list=[ctx1])
+    assert len(collection) == 1
+
+    ctx2 = ContextType({"b": 2})
+    collection.append(ctx2)
+    assert len(collection) == 2
+
+    # Verify that appending a non-ContextType raises a TypeError.
+    with pytest.raises(TypeError):
+        collection.append("not a ContextType")
+
+
+def test_get_value_demonstration():
+    # Global context with some scientific metadata.
+    global_context = {"global_info": "Earth Science", "unit": "meters"}
+    # Individual contexts with measurement data.
+    measurement1 = ContextType({"local_info": 42, "precision": 0.01})
+    measurement2 = ContextType(
+        {
+            "local_info": 100,
+            "precision": 0.02,
+            "key_unique_for_item_2": "This is measurement 2",
+        }
+    )
+
+    collection = ContextCollectionType(
+        collection_context=global_context, context_list=[measurement1, measurement2]
+    )
+
+    # a. Retrieving keys defined only in the global context returns single values.
+    assert collection.get_value("global_info") == "Earth Science"
+    assert collection.get_value("unit") == "meters"
+
+    # b. Retrieving an individual key ('local_info') returns a list of values.
+    local_info_val = collection.get_value("local_info")
+    assert isinstance(local_info_val, list)
+    assert local_info_val == [42, 100]
+
+    # c. Retrieving a key defined only in one individual context returns a list with None for missing values.
+    unique_val = collection.get_value("key_unique_for_item_2")
+    assert isinstance(unique_val, list)
+    assert unique_val == [None, "This is measurement 2"]
+
+    # d. Retrieving a non-existent key returns None.
+    assert collection.get_value("unknown") is None
+
+
+def test_set_value_demonstration():
+    # Global context with metadata.
+    global_context = {"global_info": "Earth Science", "unit": "meters"}
+    # Individual contexts with measurement values.
+    measurement1 = ContextType({"local_info": 42, "precision": 0.01})
+    measurement2 = ContextType({"local_info": 100, "precision": 0.02})
+
+    collection = ContextCollectionType(
+        collection_context=global_context, context_list=[measurement1, measurement2]
+    )
+
+    # a. Update the global key in the collection.
+    collection.set_value("global_info", "Atmospheric Science")
+    assert collection.get_value("global_info") == "Atmospheric Science"
+
+    # b. Set a new global key in the collection.
+    collection.set_value("planet", "Venus")
+    assert collection.get_value("planet") == "Venus"
+
+    # c. Update an individual key for the first context using set_item_value.
+    collection.set_item_value(0, "local_info", 123)
+    local_val = collection.get_value("local_info")
+    assert local_val == [123, 100]
+
+    # d. Update an individual key for all contexts using set_value.
+    collection.set_value("local_info", 84)
+    local_val_updated = collection.get_value("local_info")
+    assert local_val_updated == [84, 84]

--- a/tests/test_context_types.py
+++ b/tests/test_context_types.py
@@ -31,7 +31,7 @@ def test_context_type():
 def test_context_collection_type():
     context1 = ContextType({"key1": "value1"})
     context2 = ContextType({"key2": "value2"})
-    collection = ContextCollectionType([context1, context2])
+    collection = ContextCollectionType(context_list=[context1, context2])
 
     assert len(collection) == 2
     assert collection[0] == context1

--- a/tests/test_image_pipeline_slicing.py
+++ b/tests/test_image_pipeline_slicing.py
@@ -63,7 +63,9 @@ def random_context_collection():
     """
     Pytest fixture providing a ContextCollectionType with 5 distinct context items.
     """
-    return ContextCollectionType([ContextType({"param": i}) for i in range(5)])
+    return ContextCollectionType(
+        context_list=[ContextType({"param": i}) for i in range(5)]
+    )
 
 
 def test_pipeline_slicing_with_single_context(

--- a/tests/test_pipeline_and_slicing.py
+++ b/tests/test_pipeline_and_slicing.py
@@ -38,7 +38,9 @@ def empty_context_collection():
     """Pytest fixture for providing an empty context collection with the
     same size as the number of elements in IntDataCollection."""
 
-    return ContextCollectionType([ContextType(), ContextType(), ContextType()])
+    return ContextCollectionType(
+        context_list=[ContextType(), ContextType(), ContextType()]
+    )
 
 
 def test_pipeline_execution(int_data, empty_context):


### PR DESCRIPTION
- Refine ContextCollectionType's constructor to clearly document and handle both dict and ContextType inputs for global context.
- Update __str__ method in ContextCollectionType to display collection length, global context, and individual contexts.
- Adjust set_value behavior to update the global context or all individual contexts.
- Ensure set_item_value raises an error when attempting to update a key in the global context.
- Update ContextType to accept an optional logger and instantiate a default Logger if not provided.
- Improve docstrings and inline comments across ContextCollectionType methods (get_item, get_value, set_value, etc.) to clearly describe merging behavior and conflict handling.

- Minor improvements in Logger initialization to set default log levels and console output only once.
- Update tests to use keyword argument “context_list” for clarity in constructing ContextCollectionType.