### PR TITLE
Pipeline _add_node method looks to base_data_type if Node is Collection

### DIFF
--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -142,7 +142,9 @@ class Pipeline(PayloadOperation):
                             output type of the last `AlgorithmNode`.
         """
 
-        def _get_base_type(data_type):
+        def _get_base_type(
+            data_type: type[BaseDataType] | type[DataCollectionType],
+        ) -> type[BaseDataType]:
             """Returns the base type if data_type is a DataCollectionType, else returns data_type."""
             if isinstance(data_type, type) and issubclass(
                 data_type, DataCollectionType

--- a/tests/test_image_pipeline.py
+++ b/tests/test_image_pipeline.py
@@ -103,25 +103,3 @@ def test_image_pipeline_execution(image_stack_data, random_image1, random_image2
     print(
         "==============================================================================="
     )
-
-
-def test_image_pipeline_invalid_configuration():
-    """
-    Test that an invalid pipeline configuration raises an AssertionError.
-    """
-
-    # Define invalid node configurations
-    node_configurations = [
-        {
-            "operation": ImageAddition,
-            "parameters": {},
-        },
-        {
-            "operation": StackToImageMeanProjector,
-            "parameters": {},
-        },
-    ]
-
-    # Check that initializing the pipeline raises an AssertionError
-    with pytest.raises(AssertionError):
-        _ = Pipeline(node_configurations)

--- a/tests/test_pipeline_and_slicing.py
+++ b/tests/test_pipeline_and_slicing.py
@@ -10,8 +10,8 @@ from .test_utils import (
     FloatMultiplyAlgorithm,
     FloatCollectValueProbe,
     FloatCollectionSumAlgorithm,
-    IntMultiplyAlgorithm,
 )
+from .test_string_specialization import HelloOperation
 
 
 # Start test
@@ -230,8 +230,7 @@ def test_image_pipeline_invalid_configuration():
             "parameters": {"factor": 2},
         },
         {
-            "operation": IntMultiplyAlgorithm,
-            "parameters": {"factor": 2},
+            "operation": HelloOperation,
         },
     ]
 

--- a/tests/test_pipeline_and_slicing.py
+++ b/tests/test_pipeline_and_slicing.py
@@ -9,19 +9,21 @@ from .test_utils import (
     FloatDataCollection,
     FloatMultiplyAlgorithm,
     FloatCollectValueProbe,
+    FloatCollectionSumAlgorithm,
+    IntMultiplyAlgorithm,
 )
 
 
 # Start test
 @pytest.fixture
-def int_data():
-    """Pytest fixture for providing an IntDataType instance with generated integer data."""
+def float_data():
+    """Pytest fixture for providing an FloatDataType instance with generated integer data."""
     return FloatDataType(5.0)
 
 
 @pytest.fixture
-def int_data_collection():
-    """Pytest fixture for providing an IntDataCollection instance with generated integer data."""
+def float_data_collection():
+    """Pytest fixture for providing an FloatDataCollection instance with generated integer data."""
     return FloatDataCollection.from_list(
         [FloatDataType(1.0), FloatDataType(2.0), FloatDataType(3.0)]
     )
@@ -41,7 +43,7 @@ def empty_context_collection():
     return ContextCollectionType([ContextType(), ContextType(), ContextType()])
 
 
-def test_pipeline_execution(int_data, empty_context):
+def test_pipeline_execution(float_data, empty_context):
     """Test the execution of a pipeline with multiple nodes."""
     # Define node configurations
     node_configurations = [
@@ -76,7 +78,7 @@ def test_pipeline_execution(int_data, empty_context):
     pipeline = Pipeline(node_configurations)
 
     # Process the data
-    data, context = pipeline.process(int_data, empty_context)
+    data, context = pipeline.process(float_data, empty_context)
 
     assert "final_keyword" in context.keys()
     assert context.get_value("final_keyword") == 30
@@ -86,7 +88,7 @@ def test_pipeline_execution(int_data, empty_context):
     assert pipeline.get_probe_results()["Node 3/FloatCollectValueProbe"][0] == 30.0
 
 
-def test_pipeline_execution_with_single_context(int_data_collection, empty_context):
+def test_pipeline_execution_with_single_context(float_data_collection, empty_context):
     """Test the execution of a pipeline with single context.
     The FloatDataCollection is sliced into individual FloatDataType objects,
     and the same context is passed to each sliced item.
@@ -111,7 +113,7 @@ def test_pipeline_execution_with_single_context(int_data_collection, empty_conte
     pipeline = Pipeline(node_configurations)
 
     # Process the data
-    data, context = pipeline.process(int_data_collection, empty_context)
+    data, context = pipeline.process(float_data_collection, empty_context)
 
     assert isinstance(data, FloatDataCollection)
     assert len(data) == 3
@@ -127,8 +129,54 @@ def test_pipeline_execution_with_single_context(int_data_collection, empty_conte
     ]
 
 
+def test_pipeline_execution_inverted_order(float_data_collection, empty_context):
+    """Test the execution of a pipeline with multiple nodes in inverted order.
+    The FloatDataCollection is sliced into individual FloatDataType objects,
+    and the same context is passed to each sliced item.
+    The FloatCollectionSumAlgorithm should sum the values of the FloatDataType objects.
+    The final output should be a FloatDataType instance with the sum of the values of the FloatDataType objects.
+    The context should remain a single ContextType instance."""
+    # Define node configurations
+    node_configurations = [
+        {
+            "operation": FloatMultiplyAlgorithm,
+            "parameters": {"factor": 2},
+        },
+        {
+            "operation": FloatCollectValueProbe,
+        },
+        {
+            "operation": FloatCollectValueProbe,
+            "context_keyword": "mock_keyword",
+        },
+        {
+            "operation": "rename:mock_keyword:final_keyword",
+        },
+        {
+            "operation": FloatCollectionSumAlgorithm,
+        },
+    ]
+
+    # Create a pipeline
+    pipeline = Pipeline(node_configurations)
+
+    # Process the data
+    data, context = pipeline.process(float_data_collection, empty_context)
+
+    assert isinstance(data, FloatDataType)
+    assert data.data == 12.0
+    assert isinstance(context, ContextType)
+    assert "final_keyword" in context.keys()
+    assert context.get_value("final_keyword") == [2.0, 4.0, 6.0]
+    assert pipeline.get_probe_results()["Node 2/FloatCollectValueProbe"][0] == [
+        2.0,
+        4.0,
+        6.0,
+    ]
+
+
 def test_pipeline_slicing_with_context_collection(
-    int_data_collection, empty_context_collection
+    float_data_collection, empty_context_collection
 ):
     """Test the execution of a pipeline with slicing and context collection.
     The FloatDataCollection is sliced into individual FloatDataType objects, and the context collection
@@ -152,7 +200,7 @@ def test_pipeline_slicing_with_context_collection(
     # Create a pipeline
     pipeline = Pipeline(node_configurations)
 
-    data, context = pipeline.process(int_data_collection, empty_context_collection)
+    data, context = pipeline.process(float_data_collection, empty_context_collection)
     print(context)
     assert isinstance(data, FloatDataCollection)
     assert len(data) == 3
@@ -168,3 +216,25 @@ def test_pipeline_slicing_with_context_collection(
         pipeline.get_probe_results()["Node 3/FloatCollectValueProbe"][0]
         == expected_context_values
     )
+
+
+def test_image_pipeline_invalid_configuration():
+    """
+    Test that an invalid pipeline configuration raises an AssertionError.
+    """
+
+    # Define invalid node configurations
+    node_configurations = [
+        {
+            "operation": FloatMultiplyAlgorithm,
+            "parameters": {"factor": 2},
+        },
+        {
+            "operation": IntMultiplyAlgorithm,
+            "parameters": {"factor": 2},
+        },
+    ]
+
+    # Check that initializing the pipeline raises an AssertionError
+    with pytest.raises(AssertionError):
+        _ = Pipeline(node_configurations)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,16 +13,6 @@ class FloatDataType(BaseDataType[float]):
         return True
 
 
-# Concrete implementation of BaseDataType for testing in string
-class IntDataType(BaseDataType[int]):
-    """A data type for integers."""
-
-    def validate(self, data: int) -> bool:
-        if not isinstance(data, int):
-            raise TypeError("Data must be an integer")
-        return True
-
-
 # Concrete implementation of DataCollectionType for testing
 class FloatDataCollection(DataCollectionType[FloatDataType, list]):
     """A collection of IntDataType objects."""
@@ -61,19 +51,6 @@ class FloatAlgorithm(DataAlgorithm):
         return FloatDataType
 
 
-# Concrete implementation of DataAlgorithm
-class IntAlgorithm(DataAlgorithm):
-    """An algorithm specialized for processing IntDataType data."""
-
-    @classmethod
-    def input_data_type(cls):
-        return IntDataType
-
-    @classmethod
-    def output_data_type(cls):
-        return IntDataType
-
-
 class FloatCollectionMergeAlgorithm(DataAlgorithm):
     """An algorithm specialized for merging FloatDataCollection data."""
 
@@ -100,13 +77,6 @@ class FloatMultiplyAlgorithm(FloatAlgorithm):
 
     def _operation(self, data, factor, *args, **kwargs):
         return FloatDataType(data.data * factor)
-
-
-class IntMultiplyAlgorithm(IntAlgorithm):
-    """An algorithm specialized for multiplying IntDataType data."""
-
-    def _operation(self, data, factor, *args, **kwargs):
-        return IntDataType(data.data * factor)
 
 
 class FloatCollectionSumAlgorithm(FloatCollectionMergeAlgorithm):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,16 @@ class FloatDataType(BaseDataType[float]):
         return True
 
 
+# Concrete implementation of BaseDataType for testing in string
+class IntDataType(BaseDataType[int]):
+    """A data type for integers."""
+
+    def validate(self, data: int) -> bool:
+        if not isinstance(data, int):
+            raise TypeError("Data must be an integer")
+        return True
+
+
 # Concrete implementation of DataCollectionType for testing
 class FloatDataCollection(DataCollectionType[FloatDataType, list]):
     """A collection of IntDataType objects."""
@@ -40,7 +50,7 @@ class FloatDataCollection(DataCollectionType[FloatDataType, list]):
 
 # Concrete implementation of DataAlgorithm
 class FloatAlgorithm(DataAlgorithm):
-    """An algorithm specialized for processing IntDataType data."""
+    """An algorithm specialized for processing FloatDataType data."""
 
     @classmethod
     def input_data_type(cls):
@@ -51,8 +61,21 @@ class FloatAlgorithm(DataAlgorithm):
         return FloatDataType
 
 
+# Concrete implementation of DataAlgorithm
+class IntAlgorithm(DataAlgorithm):
+    """An algorithm specialized for processing IntDataType data."""
+
+    @classmethod
+    def input_data_type(cls):
+        return IntDataType
+
+    @classmethod
+    def output_data_type(cls):
+        return IntDataType
+
+
 class FloatCollectionMergeAlgorithm(DataAlgorithm):
-    """An algorithm specialized for merging IntDataCollection data."""
+    """An algorithm specialized for merging FloatDataCollection data."""
 
     @classmethod
     def input_data_type(cls):
@@ -65,7 +88,7 @@ class FloatCollectionMergeAlgorithm(DataAlgorithm):
 
 # Concrete implementation of DataProbe
 class Float(DataProbe):
-    """A probe specialized for processing IntDataType data."""
+    """A probe specialized for processing FloatDataType data."""
 
     @classmethod
     def input_data_type(cls):
@@ -73,10 +96,17 @@ class Float(DataProbe):
 
 
 class FloatMultiplyAlgorithm(FloatAlgorithm):
-    """An algorithm specialized for multiplying IntDataType data."""
+    """An algorithm specialized for multiplying FloatDataType data."""
 
     def _operation(self, data, factor, *args, **kwargs):
         return FloatDataType(data.data * factor)
+
+
+class IntMultiplyAlgorithm(IntAlgorithm):
+    """An algorithm specialized for multiplying IntDataType data."""
+
+    def _operation(self, data, factor, *args, **kwargs):
+        return IntDataType(data.data * factor)
 
 
 class FloatCollectionSumAlgorithm(FloatCollectionMergeAlgorithm):


### PR DESCRIPTION
## Description

This MR refactors the pipeline’s type validation logic to accommodate newly introduced pipeline slicing strategies, enhancing flexibility in handling data types across nodes.


### Background

Previously, the pipeline enforced strict input/output type matching between consecutive nodes to ensure topology consistency. However, with the introduction of slicing strategies, this rigid validation no longer reflects the pipeline’s capabilities.

### Changes

* `SingleNode (SingleDataType)` → `CollectionNode (CollectionDataType)`
This is now valid because the pipeline can automatically slice the CollectionData into individual elements, process them through the SingleNode, and return a CollectionData as output.
* Addition of a helper function in `_add_nodes` method to retrieve the base data type of the node in case it is a `CollectionType`. The validation now focuses on base data types, ignoring the collection wrapping when appropriate.
* Added invalid pipeline configuration case in `test_pipeline_and_slicing.py`, where it raises an error when having nodes with different base data types
* Added test case of SingleDataType -> CollectionDataType  in pytest.