### PR TITLE
Added same parameter to viewers. Removed interactive title an x/y labels

### DIFF
--- a/semantiva/payload_operations/nodes.py
+++ b/semantiva/payload_operations/nodes.py
@@ -366,7 +366,10 @@ class ContextNode(PipelineNode):
         Returns:
             tuple[BaseDataType, ContextType]: A tuple containing the processed data and context.
         """
-        return data, self.processor.operate_context(context)
+        self.stop_watch.start()
+        updated_context = self.processor.operate_context(context)
+        self.stop_watch.stop()
+        return data, updated_context
 
 
 class OperationNode(DataNode):

--- a/semantiva/specializations/image/image_viewers.py
+++ b/semantiva/specializations/image/image_viewers.py
@@ -87,17 +87,19 @@ class ImageInteractiveViewer:
         "Large (1000x800)": {"figsize": (10, 8), "labelsize": 14},
     }
 
-    @classmethod
-    def view(
-        cls,
+    def __init__(
+        self,
         data: ImageDataType,
-        title: str = "",
-        colorbar: bool = False,
-        cmap: str = "viridis",
-        log_scale: bool = False,
+        title: str,
+        colorbar: bool,
+        cmap: str,
+        log_scale: bool,
+        xlabel: str,
+        ylabel: str,
     ):
-        """Create an interactive image viewer with ipywidgets."""
-
+        self.title = title
+        self.xlabel = xlabel
+        self.ylabel = ylabel
         # Widgets
         colorbar_widget = widgets.Checkbox(value=colorbar, description="Colorbar")
         log_scale_widget = widgets.Checkbox(value=log_scale, description="Log Scale")
@@ -117,12 +119,9 @@ class ImageInteractiveViewer:
             step=0.1,
             description="vmax",
         )
-        title_widget = widgets.Text(value=title, description="Title:")
-        xlabel_widget = widgets.Text(value="", description="X Label:")
-        ylabel_widget = widgets.Text(value="", description="Y Label:")
 
         figure_size_widget = widgets.Dropdown(
-            options=list(cls.FIGURE_OPTIONS.keys()),
+            options=list(self.FIGURE_OPTIONS.keys()),
             value="Medium (700x500)",
             description="Figure Size:",
         )
@@ -144,16 +143,13 @@ class ImageInteractiveViewer:
 
         # Bind widgets to the plotting function
         interactive_plot = widgets.interactive(
-            cls._update_plot,
+            self._update_plot,
             data=widgets.fixed(data),
             colorbar=colorbar_widget,
             log_scale=log_scale_widget,
             cmap=cmap_widget,
             vmin=vmin_widget,
             vmax=vmax_widget,
-            title=title_widget,
-            xlabel=xlabel_widget,
-            ylabel=ylabel_widget,
             figure_size=figure_size_widget,
         )
 
@@ -161,30 +157,41 @@ class ImageInteractiveViewer:
         display(interactive_plot)
 
     @classmethod
-    def _update_plot(
+    def view(
         cls,
+        data: ImageDataType,
+        title: str = "",
+        colorbar: bool = False,
+        cmap: str = "viridis",
+        log_scale: bool = False,
+        xlabel: str = "",
+        ylabel: str = "",
+    ):
+        """Create an interactive image viewer with ipywidgets."""
+
+        cls(data, title, colorbar, cmap, log_scale, xlabel, ylabel)
+
+    def _update_plot(
+        self,
         data: ImageDataType,
         colorbar: bool,
         log_scale: bool,
         cmap: str,
         vmin: float,
         vmax: float,
-        title: str,
-        xlabel: str,
-        ylabel: str,
         figure_size: str,
     ):
         """Update plot based on widget values."""
-        fig_options = cls.FIGURE_OPTIONS[figure_size]
+        fig_options = self.FIGURE_OPTIONS[figure_size]
         figsize = fig_options["figsize"]
         labelsize = fig_options["labelsize"]
 
         plt.figure(figsize=figsize)
         norm = LogNorm(vmin=vmin, vmax=vmax) if log_scale else None
         plt.imshow(data.data, cmap=cmap, norm=norm)
-        plt.title(title, fontsize=labelsize + 2)
-        plt.xlabel(xlabel, fontsize=labelsize)
-        plt.ylabel(ylabel, fontsize=labelsize)
+        plt.title(self.title, fontsize=labelsize + 2)
+        plt.xlabel(self.xlabel, fontsize=labelsize)
+        plt.ylabel(self.ylabel, fontsize=labelsize)
         plt.xticks(fontsize=labelsize - 2)
         plt.yticks(fontsize=labelsize - 2)
         if colorbar:

--- a/tests/test_image_interactive_viewer.py
+++ b/tests/test_image_interactive_viewer.py
@@ -10,6 +10,12 @@ from semantiva.specializations.image.image_viewers import (
 from semantiva.specializations.image.image_data_types import ImageDataType
 
 
+@pytest.fixture(autouse=True)
+def disable_plt_show(monkeypatch):
+    """Prevents matplotlib figures from being displayed during pytest runs."""
+    monkeypatch.setattr(plt, "show", lambda: None)
+
+
 # Sample test data
 @pytest.fixture
 def test_image():
@@ -28,7 +34,7 @@ def test_figure_options():
 
 def test_generate_widgets(test_image):
     """Test that interactive widgets are correctly created."""
-    viewer = ImageInteractiveViewer()
+    viewer = ImageInteractiveViewer.view(test_image)
 
     # Create widgets
     colorbar_widget = Checkbox(value=False, description="Colorbar")
@@ -85,16 +91,13 @@ def test_update_plot(monkeypatch, test_image):
     monkeypatch.setattr(plt, "show", mock_show)
 
     # Call update_plot with dummy values
-    ImageInteractiveViewer._update_plot(
+    ImageInteractiveViewer.view(test_image)._update_plot(
         test_image,
         colorbar=True,
         log_scale=True,
         cmap="plasma",
         vmin=0.1,
         vmax=1.0,
-        title="Test Plot",
-        xlabel="X Axis",
-        ylabel="Y Axis",
         figure_size="Medium (700x500)",
     )
 


### PR DESCRIPTION
### Changes


- All viewers now share the same parameters. It is possible now to define title, x/y label, colorbar, colormap and log scale through the `view` method. 
- `ImageInteractiveViewer` do not have interactive x and y labels and text. Now those parameter should be define in `view()` method.
- Added time tracking in context node

Bellow we se example of those changes in the viewers

![image](https://github.com/user-attachments/assets/fcd3e03b-34e8-4efb-b66e-2d77afeac75a)
![image](https://github.com/user-attachments/assets/6fb09ff2-35eb-4cc6-bc92-805dd07a60eb)
![image](https://github.com/user-attachments/assets/e0237905-e6ef-4220-9c6d-bc0bec510189)
![image](https://github.com/user-attachments/assets/0b5addcb-32f2-454f-a834-fb5d659ca96a)
![image](https://github.com/user-attachments/assets/332b1499-7f3e-47c6-a205-be79338530a9)
![image](https://github.com/user-attachments/assets/89fb9460-39ca-4b65-8679-165971d3fd8c)


