### PR TITLE
Feature: Enable DataSource and DataSink injection into pipelines

### DIFF
--- a/semantiva/component_loader/component_loader.py
+++ b/semantiva/component_loader/component_loader.py
@@ -152,6 +152,9 @@ class ComponentLoader:
         cls._registered_modules.add("semantiva.specializations.image.image_operations")
         cls._registered_modules.add("semantiva.specializations.image.image_probes")
         cls._registered_modules.add("semantiva.context_processors.context_processors")
+        cls._registered_modules.add(
+            "semantiva.specializations.image.image_loaders_savers_generators"
+        )
 
     @classmethod
     def register_paths(cls, paths: str | List[str]):

--- a/semantiva/context_processors/context_processors.py
+++ b/semantiva/context_processors/context_processors.py
@@ -34,8 +34,8 @@ class ContextProcessor(ABC):
             ContextType: The modified (or unchanged) context after the operation.
         """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         return BaseDataType
 
     def get_processing_parameter_names(self) -> List[str]:

--- a/semantiva/data_io/data_io.py
+++ b/semantiva/data_io/data_io.py
@@ -46,8 +46,9 @@ class DataSource(ABC):
         """
         return self._get_data(*args, **kwargs)
 
+    @staticmethod
     @abstractmethod
-    def output_data_type(self):
+    def output_data_type():
         """
         Define the type of data provided by this source.
 
@@ -55,6 +56,10 @@ class DataSource(ABC):
             type: The data type provided by the source.
         """
         ...
+
+    @classmethod
+    def __str__(cls) -> str:
+        return f"{cls.__name__}"
 
 
 class PayloadSource(ABC):
@@ -97,8 +102,9 @@ class PayloadSource(ABC):
         """
         return self._get_payload(*args, **kwargs)
 
+    @staticmethod
     @abstractmethod
-    def output_data_type(self) -> BaseDataType:
+    def output_data_type() -> BaseDataType:
         """
         Define the type of payload provided by this source.
 
@@ -106,6 +112,10 @@ class PayloadSource(ABC):
             BaseDataType: The data type provided by the source.
         """
         ...
+
+    @classmethod
+    def __str__(cls) -> str:
+        return f"{cls.__name__}"
 
 
 class DataSink(ABC, Generic[T]):
@@ -148,14 +158,19 @@ class DataSink(ABC, Generic[T]):
         """
         return self._send_data(data, *args, **kwargs)
 
+    @staticmethod
     @abstractmethod
-    def input_data_type(self) -> BaseDataType[T]:
+    def input_data_type() -> BaseDataType[T]:
         """
         Define the type of data consumed by this sink.
 
         Returns:
             BaseDataType: The data type consumed by the sink.
         """
+
+    @classmethod
+    def __str__(cls) -> str:
+        return f"{cls.__name__}"
 
 
 class PayloadSink(ABC, Generic[T]):
@@ -201,11 +216,16 @@ class PayloadSink(ABC, Generic[T]):
         """
         self._send_payload(data, context, *args, **kwargs)
 
+    @staticmethod
     @abstractmethod
-    def input_data_type(self) -> BaseDataType[T]:
+    def input_data_type() -> BaseDataType[T]:
         """
         Define the type of data consumed by this sink.
 
         Returns:
             BaseDataType: The data type consumed by the sink.
         """
+
+    @classmethod
+    def __str__(cls) -> str:
+        return f"{cls.__name__}"

--- a/semantiva/data_processors/data_io_wrapper_factory.py
+++ b/semantiva/data_processors/data_io_wrapper_factory.py
@@ -1,0 +1,96 @@
+import inspect
+from typing import Type, List
+from ..data_types.data_types import BaseDataType, NoDataType
+from ..context_processors.context_types import ContextType
+from ..data_io import DataSource, PayloadSource, DataSink, PayloadSink
+from ..data_processors.data_processors import (
+    DataOperation,
+)
+
+
+class DataIOWrapperFactory:
+    """
+    A factory class for wrapping data IO classes into data processors.
+
+    This class provides a method for creating a data processor instance based on the provided class name.
+    """
+
+    @classmethod
+    def create_data_operation(
+        cls,
+        data_io_class: (
+            Type[DataSource] | Type[PayloadSource] | Type[DataSink] | Type[PayloadSink]
+        ),
+    ):
+        """
+        Dynamically creates a subclass of DataOperation that wraps a data IO class.
+
+        Args:
+            data_io_class (Type[DataSource] | Type[PayloadSource] | Type[DataSink] | Type[PayloadSink]):
+                The data IO class to wrap in a DataOperation subclass.
+        Returns:
+            Type[DataOperation]: A new subclass of DataOperation with the specified I/O data types.
+        """
+
+        methods: dict = {}
+
+        if issubclass(data_io_class, (DataSource, PayloadSource)):
+
+            def input_data_type_method() -> Type[BaseDataType]:
+                return NoDataType
+
+            def output_data_type_method() -> Type[BaseDataType]:
+                return type(data_io_class.output_data_type())
+
+            if issubclass(data_io_class, DataSource):
+
+                def _process_logic_method(
+                    self, data: BaseDataType, *args, **kwargs
+                ) -> BaseDataType:
+                    data_io_instance = data_io_class()
+                    loaded_data = data_io_instance.get_data(*args, **kwargs)
+                    return loaded_data
+
+                def get_processing_parameter_names(cls) -> List[str]:
+                    """
+                    Retrieve the names of parameters required by the `_get_data` method.
+
+                    Returns:
+                        List[str]: A list of parameter names (excluding `self` and `data`).
+                    """
+                    my_class = data_io_class()
+                    print(data_io_class.__dict__)
+                    signature = inspect.signature(data_io_class._get_data)
+                    return [
+                        param.name
+                        for param in signature.parameters.values()
+                        if param.name not in {"self", "data"}
+                        and param.kind
+                        not in {
+                            inspect.Parameter.VAR_POSITIONAL,
+                            inspect.Parameter.VAR_KEYWORD,
+                        }
+                    ]
+
+        elif issubclass(data_io_class, (DataSink, PayloadSink)):
+
+            def input_data_type_method() -> Type[BaseDataType]:
+                return type(data_io_class.input_data_type())
+
+            def output_data_type_method() -> Type[BaseDataType]:
+                return type(data_io_class.input_data_type())
+
+        else:
+            raise ValueError(f"Invalid data IO class: {data_io_class}.")
+
+        methods["_process_logic"] = _process_logic_method
+        methods["input_data_type"] = staticmethod(input_data_type_method)
+        methods["output_data_type"] = staticmethod(output_data_type_method)
+        methods["get_processing_parameter_names"] = classmethod(
+            get_processing_parameter_names
+        )
+
+        # Create a new type that extends DataOperation
+        class_name = f"{data_io_class.__name__}"
+        generated_class = type(class_name, (DataOperation,), methods)
+        return generated_class

--- a/semantiva/data_processors/data_io_wrapper_factory.py
+++ b/semantiva/data_processors/data_io_wrapper_factory.py
@@ -6,6 +6,7 @@ from ..data_io import DataSource, PayloadSource, DataSink, PayloadSink
 from ..data_processors.data_processors import (
     DataOperation,
 )
+from ..logger import Logger
 
 
 class DataIOWrapperFactory:
@@ -36,11 +37,14 @@ class DataIOWrapperFactory:
 
         if issubclass(data_io_class, (DataSource, PayloadSource)):
 
-            def input_data_type_method() -> Type[BaseDataType]:
+            def get_no_data_type():
                 return NoDataType
 
-            def output_data_type_method() -> Type[BaseDataType]:
-                return type(data_io_class.output_data_type())
+            def input_data_type_method() -> BaseDataType:
+                return get_no_data_type()
+
+            def output_data_type_method() -> BaseDataType:
+                return data_io_class.output_data_type()
 
             if issubclass(data_io_class, DataSource):
 
@@ -72,13 +76,76 @@ class DataIOWrapperFactory:
                         }
                     ]
 
+            if issubclass(data_io_class, PayloadSource):
+
+                def _process_logic_method(
+                    self, data: BaseDataType, *args, **kwargs
+                ) -> BaseDataType:
+                    data_io_instance = data_io_class()
+                    loaded_data = data_io_instance._get_payload(*args, **kwargs)[0]
+                    Logger().warning(
+                        f"Context loading from Wrapped PayloadSource in pipelines is not supported ({data_io_class.__name__})"
+                    )
+                    return loaded_data
+
+                def get_processing_parameter_names(cls) -> List[str]:
+                    """
+                    Retrieve the names of parameters required by the `_get_data` method.
+
+                    Returns:
+                        List[str]: A list of parameter names (excluding `self` and `data`).
+                    """
+                    my_class = data_io_class()
+                    print(data_io_class.__dict__)
+                    signature = inspect.signature(data_io_class._get_payload)
+                    return [
+                        param.name
+                        for param in signature.parameters.values()
+                        if param.name not in {"self", "data"}
+                        and param.kind
+                        not in {
+                            inspect.Parameter.VAR_POSITIONAL,
+                            inspect.Parameter.VAR_KEYWORD,
+                        }
+                    ]
+
         elif issubclass(data_io_class, (DataSink, PayloadSink)):
 
-            def input_data_type_method() -> Type[BaseDataType]:
-                return type(data_io_class.input_data_type())
+            def input_data_type_method() -> BaseDataType:
+                return data_io_class().input_data_type()
 
-            def output_data_type_method() -> Type[BaseDataType]:
-                return type(data_io_class.input_data_type())
+            def output_data_type_method() -> BaseDataType:
+                return data_io_class().input_data_type()
+
+            if issubclass(data_io_class, DataSink):
+
+                def _process_logic_method(
+                    self, data: BaseDataType, *args, **kwargs
+                ) -> BaseDataType:
+                    data_io_instance = data_io_class()
+                    data_io_instance.send_data(data, *args, **kwargs)
+                    return data
+
+                def get_processing_parameter_names(cls) -> List[str]:
+                    """
+                    Retrieve the names of parameters required by the `_get_data` method.
+
+                    Returns:
+                        List[str]: A list of parameter names (excluding `self` and `data`).
+                    """
+                    my_class = data_io_class()
+
+                    signature = inspect.signature(data_io_class._send_data)
+                    return [
+                        param.name
+                        for param in signature.parameters.values()
+                        if param.name not in {"self", "data"}
+                        and param.kind
+                        not in {
+                            inspect.Parameter.VAR_POSITIONAL,
+                            inspect.Parameter.VAR_KEYWORD,
+                        }
+                    ]
 
         else:
             raise ValueError(f"Invalid data IO class: {data_io_class}.")
@@ -93,4 +160,6 @@ class DataIOWrapperFactory:
         # Create a new type that extends DataOperation
         class_name = f"{data_io_class.__name__}"
         generated_class = type(class_name, (DataOperation,), methods)
+        assert issubclass(generated_class, DataOperation)
+        print(generated_class.signature_string())
         return generated_class

--- a/semantiva/data_processors/data_processors.py
+++ b/semantiva/data_processors/data_processors.py
@@ -28,9 +28,9 @@ class BaseDataProcessor(ABC, Generic[T]):
         else:
             self.logger = Logger()
 
-    @classmethod
+    @staticmethod
     @abstractmethod
-    def input_data_type(cls) -> Type[BaseDataType]:
+    def input_data_type() -> Type[BaseDataType]:
         """
         Define the expected type of input data for processing.
 
@@ -113,8 +113,9 @@ class BaseDataProcessor(ABC, Generic[T]):
             not in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
         ]
 
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}"
+    @classmethod
+    def __str__(cls) -> str:
+        return f"{cls.__name__}"
 
     @classmethod
     def get_processing_parameters_with_types(cls) -> List[Tuple[str, str]]:
@@ -206,15 +207,6 @@ class DataOperation(BaseDataProcessor):
         """
         return []
 
-    def __str__(self) -> str:
-        """
-        Return a string representation of the instance.
-
-        Returns:
-            str: The name of this data processing class.
-        """
-        return f"{self.__class__.__name__}"
-
     def get_created_keys(self) -> List[str]:
         """
         Retrieve a list of context keys created by the data operation.
@@ -253,9 +245,9 @@ class DataOperation(BaseDataProcessor):
 
         return f"""{cls.__name__} (DataOperation)\n\tInput Type:  {input_type}\n\tOutput Type: {output_type}\n\tParameters:{params_section}\n"""
 
-    @classmethod
+    @staticmethod
     @abstractmethod
-    def output_data_type(cls) -> Type[BaseDataType]:
+    def output_data_type() -> Type[BaseDataType]:
         """
         Define the type of output data produced by this operation.
 
@@ -293,16 +285,16 @@ class OperationTopologyFactory:
             Type[DataOperation]: A new subclass of DataOperation with the specified I/O data types.
         """
 
-        methods = {}
+        methods: dict = {}
 
-        def input_data_type_method(self_or_cls) -> Type[BaseDataType]:
+        def input_data_type_method() -> Type[BaseDataType]:
             return input_type
 
-        def output_data_type_method(self_or_cls) -> Type[BaseDataType]:
+        def output_data_type_method() -> Type[BaseDataType]:
             return output_type
 
-        methods["input_data_type"] = classmethod(input_data_type_method)
-        methods["output_data_type"] = classmethod(output_data_type_method)
+        methods["input_data_type"] = staticmethod(input_data_type_method)
+        methods["output_data_type"] = staticmethod(output_data_type_method)
 
         # Create a new type that extends DataOperation
         generated_class = type(class_name, (DataOperation,), methods)
@@ -367,8 +359,8 @@ class DataCollectionProbe(BaseDataProcessor, Generic[BaseType]):
     def __init__(self, logger=None):
         super().__init__(logger)
 
-    @classmethod
-    def input_data_type(cls) -> Type[DataCollectionType]:
+    @staticmethod
+    def input_data_type() -> Type[DataCollectionType]:
         """
         Specifies the input data type for the probe.
 

--- a/semantiva/data_types/data_types.py
+++ b/semantiva/data_types/data_types.py
@@ -163,3 +163,21 @@ class DataCollectionType(BaseDataType[S], Generic[E, S]):
         for item in items:
             instance.append(item)
         return instance
+
+
+class NoDataType(BaseDataType[None]):
+    """
+    A data type representing the absence of data in Semantiva.
+    """
+
+    def validate(self, data: None) -> bool:
+        return data is None
+
+    def __str__(self) -> str:
+        return "NoDataType"
+
+    def __init__(self, data: None = None, *args, **kwargs):
+        """
+        Initializes a NoDataType instance
+        """
+        super().__init__(data, *args, **kwargs)

--- a/semantiva/payload_operations/__init__.py
+++ b/semantiva/payload_operations/__init__.py
@@ -1,11 +1,12 @@
 from .payload_processors import PayloadProcessor
-from .nodes import (
+from .nodes.nodes import (
     DataNode,
     OperationNode,
     ProbeNode,
     ProbeContextInjectorNode,
     ProbeResultCollectorNode,
     DataProbe,
-    node_factory,
 )
+
+from .nodes.node_factory import node_factory
 from .pipeline import Pipeline

--- a/semantiva/payload_operations/nodes/io_node_factory.py
+++ b/semantiva/payload_operations/nodes/io_node_factory.py
@@ -1,0 +1,113 @@
+from ...data_io.data_io import DataSource, PayloadSource, DataSink, PayloadSink
+from typing import List, Any, Dict, Optional, Type, Tuple
+from .nodes import (
+    DataNode,
+    ContextNode,
+    OperationNode,
+    ProbeContextInjectorNode,
+    ProbeResultCollectorNode,
+)
+from ...context_processors.context_processors import ContextProcessor
+from ...logger import Logger
+from ...data_processors.data_processors import (
+    DataOperation,
+    DataProbe,
+)
+from .io_nodes import DataSourceNode, PayloadSourceNode, DataSinkNode, PayloadSinkNode
+from ...component_loader import ComponentLoader
+
+
+class DataIONodeFactory:
+    """
+    Factory class to create data I/O nodes based on the provided configuration.
+
+    This class extends the existing node_factory to support the creation of data I/O nodes.
+    """
+
+    @staticmethod
+    def create_io_node(
+        node_definition: Dict,
+        logger: Optional[Logger] = None,
+    ) -> DataNode | ContextNode:
+        """
+        Factory function to create an appropriate data I/O node instance based on the given definition.
+
+        Args:
+            node_definition (Dict): A dictionary describing the node configuration.
+            logger (Optional[Logger]): Optional logger instance for diagnostic messages.
+
+        Returns:
+            DataNode | ContextNode: An instance of a subclass of DataNode or ContextNode.
+
+        Raises:
+            ValueError: If the node definition is invalid or if the processor type is unsupported.
+        """
+        processor = node_definition.get("processor")
+        parameters = node_definition.get("parameters", {})
+        context_keyword = node_definition.get("context_keyword")
+
+        def get_class(class_name):
+            """Helper function to retrieve the class from the loader if the input is a string."""
+            if isinstance(class_name, str):
+                return ComponentLoader.get_class(class_name)
+            return class_name
+
+        # Resolve the processor class if provided as a string.
+        processor = get_class(processor)
+
+        if processor is None or not isinstance(processor, type):
+            raise ValueError("processor must be a class type or a string, not None.")
+
+        if issubclass(processor, ContextProcessor):
+            return ContextNode(processor, processor_config=parameters, logger=logger)
+
+        elif issubclass(processor, DataOperation):
+            if context_keyword is not None:
+                raise ValueError(
+                    "context_keyword must not be defined for DataOperation nodes."
+                )
+            return OperationNode(
+                processor=processor,
+                processor_parameters=parameters,
+                logger=logger,
+            )
+        elif issubclass(processor, DataProbe):
+            if context_keyword is not None:
+                return ProbeContextInjectorNode(
+                    processor=processor,
+                    context_keyword=context_keyword,
+                    processor_parameters=parameters,
+                    logger=logger,
+                )
+            else:
+                return ProbeResultCollectorNode(
+                    processor=processor,
+                    processor_parameters=parameters,
+                    logger=logger,
+                )
+        elif issubclass(processor, DataSource):
+            return DataSourceNode(
+                data_io_class=processor,
+                processor_parameters=parameters,
+                logger=logger,
+            )
+        elif issubclass(processor, PayloadSource):
+            return PayloadSourceNode(
+                data_io_class=processor,
+                processor_parameters=parameters,
+                logger=logger,
+            )
+        elif issubclass(processor, DataSink):
+            return DataSinkNode(
+                data_io_class=processor,
+                processor_parameters=parameters,
+            )
+        elif issubclass(processor, PayloadSink):
+            return PayloadSinkNode(
+                data_io_class=processor,
+                processor_parameters=parameters,
+            )
+        else:
+            raise ValueError(
+                "Unsupported processor. Processor must be of type DataOperation, DataProbe, DataSource, PayloadSource, DataSink, or PayloadSink."
+            )

--- a/semantiva/payload_operations/nodes/io_nodes.py
+++ b/semantiva/payload_operations/nodes/io_nodes.py
@@ -1,0 +1,284 @@
+from typing import Dict, Optional, Type, Tuple
+from ...data_types.data_types import BaseDataType
+from ...context_processors.context_types import ContextType
+from ...data_io import DataSource, PayloadSource, DataSink, PayloadSink
+from ...logger import Logger
+from ...data_processors.data_io_wrapper_factory import (
+    DataIOWrapperFactory,
+)
+from .nodes import DataNode
+
+
+# Lets create the new Node classes for Data I/O
+class DataSourceNode(DataNode):
+    """
+    A node that loads data from a data source.
+
+    This node wraps a DataSource to load data and inject it into the pipeline.
+
+    Attributes:
+        data_source (DataSource): The data source instance used to load data.
+    """
+
+    def __init__(
+        self,
+        data_io_class: Type[DataSource],
+        processor_parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ):
+        """
+        Initialize a DataSourceNode with the specified data source.
+
+        Args:
+            processor (Type[DataSource]): The data source class for this node.
+            processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
+            logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
+        """
+        super().__init__(
+            DataIOWrapperFactory.create_data_operation(data_io_class),
+            processor_parameters,
+            logger,
+        )
+
+    def get_created_keys(self):
+        """
+        Retrieve a list of context keys that will be created by the processor.
+
+        Returns:
+            List[str]: A list of context keys that the processor will add or create
+                       as a result of execution.
+        """
+        return []
+
+    def _execute_single_data_single_context(
+        self, data: BaseDataType, context: ContextType
+    ) -> Tuple[BaseDataType, ContextType]:
+        """
+        Process a single data item with its corresponding single context.
+
+        Args:
+            data (BaseDataType): A single data instance.
+            context (ContextType): The corresponding single context.
+
+        Returns:
+            Tuple[BaseDataType, ContextType]: The processed data and updated context.
+        """
+        self.stop_watch.start()
+        # Save the current context to be used by the processor
+        self.observer_context = context
+        parameters = self._get_processor_parameters(self.observer_context)
+        output_data = self.processor.process(data, **parameters)
+        self.stop_watch.stop()
+        return output_data, self.observer_context
+
+    def _execute_data_collection_context_collection(self, data_collection, context):
+        raise RuntimeError("Data source nodes do not support parallel slicing.")
+
+    def _execute_data_collection_single_context(self, data_collection, context):
+        raise RuntimeError("Data source nodes do not support parallel slicing.")
+
+
+class PayloadSourceNode(DataNode):
+    """
+    A node that loads data from a payload source.
+
+    This node wraps a PayloadSource to load data and inject it into the pipeline.
+
+    Attributes:
+        payload_source (PayloadSource): The payload source instance used to load data.
+    """
+
+    def __init__(
+        self,
+        data_io_class: Type[PayloadSource],
+        processor_parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ):
+        """
+        Initialize a PayloadSourceNode with the specified payload source.
+
+        Args:
+            processor (Type[PayloadSource]): The payload source class for this node.
+            processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
+            logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
+        """
+        super().__init__(
+            DataIOWrapperFactory.create_data_operation(data_io_class),
+            processor_parameters,
+            logger,
+        )
+
+    def get_created_keys(self):
+        """
+        Retrieve a list of context keys that will be created by the processor.
+
+        Returns:
+            List[str]: An empty list indicating that no keys will be created.
+        """
+        return []  # self.processor.get_created_keys()
+
+    def _execute_single_data_single_context(
+        self, data: BaseDataType, context: ContextType
+    ) -> Tuple[BaseDataType, ContextType]:
+        """
+        Process a single data item with its corresponding single context.
+
+        Args:
+            data (BaseDataType): A single data instance.
+            context (ContextType): The corresponding single context.
+
+        Returns:
+            Tuple[BaseDataType, ContextType]: The processed data and updated context.
+        """
+        self.stop_watch.start()
+        # Save the current context to be used by the processor
+        self.observer_context = context
+        parameters = self._get_processor_parameters(self.observer_context)
+        loaded_data, loaded_context = self.processor.process(data, **parameters)
+        self.stop_watch.stop()
+        # Merge context and loaded_context
+        for key, value in loaded_context.items():
+            if key in context.keys():
+                raise KeyError(f"Key '{key}' already exists in the context.")
+            context.set_value(key, value)
+        return loaded_data, context
+
+    def _execute_data_collection_context_collection(self, data_collection, context):
+        raise RuntimeError("Payload source nodes do not support parallel slicing.")
+
+    def _execute_data_collection_single_context(self, data_collection, context):
+        raise RuntimeError("Payload source nodes do not support parallel slicing.")
+
+
+class DataSinkNode(DataNode):
+    """
+    A node that saves data using a data sink.
+
+    This node wraps a DataSink to save data at the end of a pipeline.
+
+    Attributes:
+        data_sink (DataSink): The data sink instance used to save data.
+    """
+
+    def __init__(
+        self,
+        data_io_class: Type[DataSink],
+        processor_parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ):
+        """
+        Initialize a DataSinkNode with the specified data sink.
+
+        Args:
+            processor (Type[DataSink]): The data sink class for this node.
+            processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
+            logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
+        """
+        super().__init__(
+            DataIOWrapperFactory.create_data_operation(data_io_class),
+            processor_parameters,
+            logger,
+        )
+
+    def get_created_keys(self):
+        """
+        Retrieve a list of context keys that will be created by the processor.
+
+        Returns:
+            List[str]: An empty list indicating that no keys will be created.
+        """
+        return []
+
+    def _execute_single_data_single_context(
+        self, data: BaseDataType, context: ContextType
+    ) -> Tuple[BaseDataType, ContextType]:
+        """
+        Process a single data item with its corresponding single context.
+
+        Args:
+            data (BaseDataType): A single data instance.
+            context (ContextType): The corresponding single context.
+
+        Returns:
+            Tuple[BaseDataType, ContextType]: The processed data and updated context.
+        """
+        self.stop_watch.start()
+        # Save the current context to be used by the processor
+        self.observer_context = context
+        parameters = self._get_processor_parameters(self.observer_context)
+        output_data = self.processor.process(data, **parameters)
+        self.stop_watch.stop()
+        return output_data, self.observer_context
+
+    def _execute_data_collection_context_collection(self, data_collection, context):
+        raise RuntimeError("Data sink nodes do not support parallel slicing.")
+
+    def _execute_data_collection_single_context(self, data_collection, context):
+        raise RuntimeError("Data sink nodes do not support parallel slicing.")
+
+
+class PayloadSinkNode(DataNode):
+    """
+    A node that saves data using a payload sink.
+
+    This node wraps a PayloadSink to save data at the end of a pipeline.
+
+    Attributes:
+        payload_sink (PayloadSink): The payload sink instance used to save data.
+    """
+
+    def __init__(
+        self,
+        data_io_class: Type[PayloadSink],
+        processor_parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ):
+        """
+        Initialize a PayloadSinkNode with the specified payload sink.
+
+        Args:
+            processor (Type[PayloadSink]): The payload sink class for this node.
+            processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
+            logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
+        """
+        super().__init__(
+            DataIOWrapperFactory.create_data_operation(data_io_class),
+            processor_parameters,
+            logger,
+        )
+
+    def get_created_keys(self):
+        """
+        Retrieve a list of context keys that will be created by the processor.
+
+        Returns:
+            List[str]: An empty list indicating that no keys will be created.
+        """
+        return []
+
+    def _execute_single_data_single_context(
+        self, data: BaseDataType, context: ContextType
+    ) -> Tuple[BaseDataType, ContextType]:
+        """
+        Process a single data item with its corresponding single context.
+
+        Args:
+            data (BaseDataType): A single data instance.
+            context (ContextType): The corresponding single context.
+
+        Returns:
+            Tuple[BaseDataType, ContextType]: The processed data and updated context.
+        """
+        self.stop_watch.start()
+        # Save the current context to be used by the processor
+        self.observer_context = context
+        parameters = self._get_processor_parameters(self.observer_context)
+        output_data = self.processor.process(data, **parameters)
+        self.stop_watch.stop()
+        return output_data, self.observer_context
+
+    def _execute_data_collection_context_collection(self, data_collection, context):
+        raise RuntimeError("Payload sink nodes do not support parallel slicing.")
+
+    def _execute_data_collection_single_context(self, data_collection, context):
+        raise RuntimeError("Payload sink nodes do not support parallel slicing.")

--- a/semantiva/payload_operations/nodes/node_factory.py
+++ b/semantiva/payload_operations/nodes/node_factory.py
@@ -1,0 +1,92 @@
+from typing import Dict, Optional
+from ...logger import Logger
+from ...component_loader import ComponentLoader
+from ...context_processors.context_processors import ContextProcessor
+from ...data_io import DataSource, PayloadSource, DataSink, PayloadSink
+from ...data_processors.data_processors import (
+    DataOperation,
+    DataProbe,
+)
+from .io_node_factory import DataIONodeFactory
+from .nodes import (
+    DataNode,
+    ContextNode,
+    OperationNode,
+    ProbeContextInjectorNode,
+    ProbeResultCollectorNode,
+)
+
+
+# Main node factory function
+def node_factory(
+    node_definition: Dict,
+    logger: Optional[Logger] = None,
+) -> DataNode | ContextNode:
+    """
+    Factory function to create an appropriate node instance based on the given definition.
+
+    The node definition dictionary should include:
+      - "processor": The class (or a string that can be resolved to a class) for the processor.
+      - "parameters": (Optional) A dictionary of parameters for the processor.
+      - "context_keyword": (Optional) A string specifying the context key for probe injection.
+
+    Args:
+        node_definition (Dict): A dictionary describing the node configuration.
+        logger (Optional[Logger]): Optional logger instance for diagnostic messages.
+
+    Returns:
+        DataNode | ContextNode: An instance of a subclass of DataNode or ContextNode.
+
+    Raises:
+        ValueError: If the node definition is invalid or if the processor type is unsupported.
+    """
+
+    def get_class(class_name):
+        """Helper function to retrieve the class from the loader if the input is a string."""
+        if isinstance(class_name, str):
+            return ComponentLoader.get_class(class_name)
+        return class_name
+
+    processor = node_definition.get("processor")
+    parameters = node_definition.get("parameters", {})
+    context_keyword = node_definition.get("context_keyword")
+
+    # Resolve the processor class if provided as a string.
+    processor = get_class(processor)
+
+    if processor is None or not isinstance(processor, type):
+        raise ValueError("processor must be a class type or a string, not None.")
+
+    if issubclass(processor, ContextProcessor):
+        return ContextNode(processor, processor_config=parameters, logger=logger)
+
+    elif issubclass(processor, DataOperation):
+        if context_keyword is not None:
+            raise ValueError(
+                "context_keyword must not be defined for DataOperation nodes."
+            )
+        return OperationNode(
+            processor=processor,
+            processor_parameters=parameters,
+            logger=logger,
+        )
+    elif issubclass(processor, DataProbe):
+        if context_keyword is not None:
+            return ProbeContextInjectorNode(
+                processor=processor,
+                context_keyword=context_keyword,
+                processor_parameters=parameters,
+                logger=logger,
+            )
+        else:
+            return ProbeResultCollectorNode(
+                processor=processor,
+                processor_parameters=parameters,
+                logger=logger,
+            )
+    elif issubclass(processor, (DataSource, PayloadSource, DataSink, PayloadSink)):
+        return DataIONodeFactory.create_io_node(node_definition, logger)
+    else:
+        raise ValueError(
+            "Unsupported processor. Processor must be of type DataOperation or DataProbe."
+        )

--- a/semantiva/payload_operations/payload_processors.py
+++ b/semantiva/payload_operations/payload_processors.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional
 from ..context_processors.context_types import ContextType
 from ..context_processors.context_observer import ContextObserver
-from ..data_types.data_types import BaseDataType
+from ..data_types.data_types import BaseDataType, NoDataType
 from ..logger import Logger
 from ..component_loader import ComponentLoader
 
@@ -34,7 +34,9 @@ class PayloadProcessor(ContextObserver, ABC):
     def _process(self, data: BaseDataType, context: ContextType): ...
 
     def process(
-        self, data: BaseDataType, context: ContextType | dict[Any, Any]
+        self,
+        data: BaseDataType | None = None,
+        context: ContextType | dict[Any, Any] | None = None,
     ) -> tuple[BaseDataType, ContextType]:
         """
         Public method to execute the payload processing logic.
@@ -52,6 +54,8 @@ class PayloadProcessor(ContextObserver, ABC):
         Raises:
             NotImplementedError: If the `_process` method is not implemented in a subclass.
         """
+        context = context or {}
+        data = data or NoDataType()
         context_ = ContextType(context) if isinstance(context, dict) else context
         assert isinstance(
             context_, ContextType

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 from .stop_watch import StopWatch
 from .payload_processors import PayloadProcessor
-from .nodes import (
+from .nodes.nodes import (
     DataNode,
     OperationNode,
     ContextNode,
@@ -12,7 +12,7 @@ from ..logger import Logger
 from ..data_types.data_types import BaseDataType, DataCollectionType
 from ..data_processors.data_processors import DataOperation
 from ..context_processors.context_types import ContextType
-from .nodes import node_factory
+from .nodes.node_factory import node_factory
 
 
 class Pipeline(PayloadProcessor):

--- a/semantiva/specializations/audio/audio_operations.py
+++ b/semantiva/specializations/audio/audio_operations.py
@@ -14,8 +14,8 @@ class SingleChannelAudioOperation(DataOperation):
         output_data_type: Returns the type of data output by the operation.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -24,8 +24,8 @@ class SingleChannelAudioOperation(DataOperation):
         """
         return SingleChannelAudioDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         """
         Specify the output data type for the operation.
 
@@ -47,8 +47,8 @@ class DualChannelAudioOperation(DataOperation):
         output_data_type: Returns the type of data output by the operation.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -57,8 +57,8 @@ class DualChannelAudioOperation(DataOperation):
         """
         return DualChannelAudioDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         """
         Specify the output data type for the operation.
 
@@ -81,8 +81,8 @@ class DualChannelMergerOperation(DataOperation):
         output_data_type: Returns the type of data output by the operation.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -91,8 +91,8 @@ class DualChannelMergerOperation(DataOperation):
         """
         return DualChannelAudioDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         """
         Specify the output data type for the operation.
 
@@ -115,8 +115,8 @@ class SingleChannelExpanderOperation(DataOperation):
         output_data_type: Returns the type of data output by the operation.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -125,8 +125,8 @@ class SingleChannelExpanderOperation(DataOperation):
         """
         return SingleChannelAudioDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         """
         Specify the output data type for the operation.
 
@@ -149,8 +149,8 @@ class SingleChannelAudioProbe(DataProbe):
         input_data_type: Returns the expected input data type for the probe.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the probe.
 
@@ -173,8 +173,8 @@ class DualChannelAudioProbe(DataProbe):
         input_data_type: Returns the expected input data type for the probe.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the probe.
 

--- a/semantiva/specializations/image/image_data_io.py
+++ b/semantiva/specializations/image/image_data_io.py
@@ -74,7 +74,8 @@ class ImageStackSource(DataSource):
         """
         return self._get_data(*args, **kwargs)
 
-    def output_data_type(self):
+    @staticmethod
+    def output_data_type():
         return ImageStackDataType
 
 
@@ -109,7 +110,8 @@ class ImageDataSink(DataSink):
         """
         self._send_data(data, *args, **kwargs)
 
-    def input_data_type(self):
+    @staticmethod
+    def input_data_type():
         return ImageDataType
 
 
@@ -144,7 +146,8 @@ class ImageStackDataSink(DataSink):
         """
         self._send_data(data, *args, **kwargs)
 
-    def input_data_type(self):
+    @staticmethod
+    def input_data_type():
         return ImageStackDataType
 
 
@@ -183,7 +186,8 @@ class ImagePayloadSink(PayloadSink):
         """
         self._send_payload(data, context, *args, **kwargs)
 
-    def input_data_type(self):
+    @staticmethod
+    def input_data_type():
         """
         Returns the expected input data type for the data.
 
@@ -228,7 +232,8 @@ class ImageStackPayloadSource(PayloadSource):
         """
         return self._get_payload(*args, **kwargs)
 
-    def output_data_type(self):
+    @staticmethod
+    def output_data_type():
         """
         Returns the expected output data type for the data.
 

--- a/semantiva/specializations/image/image_loaders_savers_generators.py
+++ b/semantiva/specializations/image/image_loaders_savers_generators.py
@@ -315,7 +315,9 @@ class ImageDataRandomGenerator(ImageDataSource):
 class TwoDGaussianImageGenerator(ImageDataSource):
     """Generates an image with a 2D Gaussian signal with optional rotation."""
 
+    # @classmethod
     def _get_data(
+        # cls,
         self,
         x_0: float | int,  # x position
         y_0: float | int,  # y position

--- a/semantiva/specializations/image/image_processors.py
+++ b/semantiva/specializations/image/image_processors.py
@@ -14,8 +14,8 @@ class ImageOperation(DataOperation):
         output_data_type: Returns the type of data output by the operation.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -24,8 +24,8 @@ class ImageOperation(DataOperation):
         """
         return ImageDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         """
         Specify the output data type for the operation.
 
@@ -47,8 +47,8 @@ class ImageStackAlgorithm(DataOperation):
         output_data_type: Returns the type of data output by the operation.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -57,8 +57,8 @@ class ImageStackAlgorithm(DataOperation):
         """
         return ImageStackDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         """
         Specify the output data type for the operation.
 
@@ -80,8 +80,8 @@ class ImageStackToImageProjector(DataOperation):
         output_data_type: Returns the type of data output by the operation.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -90,8 +90,8 @@ class ImageStackToImageProjector(DataOperation):
         """
         return ImageStackDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         """
         Specify the output data type for the operation.
 
@@ -112,8 +112,8 @@ class ImageProbe(DataProbe):
         input_data_type: Returns the expected input data type.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 
@@ -134,8 +134,8 @@ class ImageStackProbe(DataProbe):
         input_data_type: Returns the expected input data type.
     """
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         """
         Specify the input data type for the operation.
 

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -30,7 +30,8 @@ class FloatDataSource(DataSource):
         # Return a fixed IntDataType for testing
         return FloatDataType(123.0)
 
-    def output_data_type(self):
+    @staticmethod
+    def output_data_type():
         # Return the type of data we are providing
         return FloatDataType
 
@@ -45,7 +46,8 @@ class IntPayloadSource(PayloadSource):
         # Return a tuple of data and context
         return (FloatDataType(456.0), DummyContext())
 
-    def output_data_type(self):
+    @staticmethod
+    def output_data_type():
         # Return the type of data in the payload
         return FloatDataType
 
@@ -63,7 +65,8 @@ class FloatDataSink(DataSink[FloatDataType]):
         # Keep track of the last data we received
         self.last_data_sent = data
 
-    def input_data_type(self):
+    @staticmethod
+    def input_data_type():
         # Return the type of data we accept
         return FloatDataType
 

--- a/tests/test_pipeline_and_slicing.py
+++ b/tests/test_pipeline_and_slicing.py
@@ -10,6 +10,7 @@ from .test_utils import (
     FloatMultiplyOperation,
     FloatCollectValueProbe,
     FloatCollectionSumOperation,
+    FloatMockDataSource,
 )
 from .test_string_specialization import HelloOperation
 
@@ -239,3 +240,25 @@ def test_image_pipeline_invalid_configuration():
     # Check that initializing the pipeline raises an AssertionError
     with pytest.raises(AssertionError):
         _ = Pipeline(node_configurations)
+
+
+def test_data_io_node():
+    """Test the execution of a pipeline with a data IO node."""
+    # Define node configurations
+    node_configurations = [
+        {
+            "processor": FloatMockDataSource,
+        },
+        {
+            "processor": FloatMultiplyOperation,
+            "parameters": {"factor": 2},
+        },
+    ]
+
+    # Create a pipeline
+    pipeline = Pipeline(node_configurations)
+
+    # Process the data
+    data, context = pipeline.process()
+
+    assert data.data == FloatMockDataSource().get_data().data * 2.0

--- a/tests/test_pipeline_and_slicing.py
+++ b/tests/test_pipeline_and_slicing.py
@@ -11,6 +11,7 @@ from .test_utils import (
     FloatCollectValueProbe,
     FloatCollectionSumOperation,
     FloatMockDataSource,
+    FloatMockDataSink,
 )
 from .test_string_specialization import HelloOperation
 
@@ -252,6 +253,10 @@ def test_data_io_node():
         {
             "processor": FloatMultiplyOperation,
             "parameters": {"factor": 2},
+        },
+        {
+            "processor": FloatMockDataSink,
+            "parameters": {"path": "mock_file.txt"},
         },
     ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # This file contains utility classes for testing the semantiva package.
 from semantiva.data_types import BaseDataType, DataCollectionType
 from semantiva.data_processors import DataOperation, DataProbe
+from semantiva.data_io import DataSource
 
 
 # Concrete implementation of BaseDataType for testing
@@ -42,24 +43,24 @@ class FloatDataCollection(DataCollectionType[FloatDataType, list]):
 class FloatOperation(DataOperation):
     """An operation specialized for processing FloatDataType data."""
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         return FloatDataType
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         return FloatDataType
 
 
 class FloatCollectionMergeOperation(DataOperation):
     """An operation specialized for merging FloatDataCollection data."""
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         return FloatDataCollection
 
-    @classmethod
-    def output_data_type(cls):
+    @staticmethod
+    def output_data_type():
         return FloatDataType
 
 
@@ -67,8 +68,8 @@ class FloatCollectionMergeOperation(DataOperation):
 class Float(DataProbe):
     """A probe specialized for processing FloatDataType data."""
 
-    @classmethod
-    def input_data_type(cls):
+    @staticmethod
+    def input_data_type():
         return FloatDataType
 
 
@@ -91,3 +92,15 @@ class FloatCollectValueProbe(Float):
 
     def _process_logic(self, data, *args, **kwargs):
         return data.data
+
+
+# Lets create a mock data source for testing
+class FloatMockDataSource(DataSource):
+    """Concrete implementation of DataSource providing FloatDataType data."""
+
+    def _get_data(self, *args, **kwargs) -> FloatDataType:
+        return FloatDataType(123.0)
+
+    @staticmethod
+    def output_data_type():
+        return FloatDataType

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # This file contains utility classes for testing the semantiva package.
 from semantiva.data_types import BaseDataType, DataCollectionType
 from semantiva.data_processors import DataOperation, DataProbe
-from semantiva.data_io import DataSource
+from semantiva.data_io import DataSource, DataSink
 
 
 # Concrete implementation of BaseDataType for testing
@@ -94,7 +94,6 @@ class FloatCollectValueProbe(Float):
         return data.data
 
 
-# Lets create a mock data source for testing
 class FloatMockDataSource(DataSource):
     """Concrete implementation of DataSource providing FloatDataType data."""
 
@@ -103,4 +102,15 @@ class FloatMockDataSource(DataSource):
 
     @staticmethod
     def output_data_type():
+        return FloatDataType
+
+
+class FloatMockDataSink(DataSink):
+    """Concrete implementation of Datasink for FloatDataType data."""
+
+    def _send_data(self, data: BaseDataType, path: str, *args, **kwargs):
+        return
+
+    @staticmethod
+    def input_data_type():
         return FloatDataType


### PR DESCRIPTION
Allow DataSource and DataSink classes to be wrapped as pipeline steps via DataIOWrapperFactory.

• Introduce DataIOWrapperFactory and DataIONodeFactory to wrap DataSource, PayloadSource, DataSink, and PayloadSink classes as pipeline nodes.
• Convert input_data_type and output_data_type methods to @staticmethod in multiple classes for consistency and easier wrapping.
• Add new node classes (DataSourceNode, PayloadSourceNode, DataSinkNode, PayloadSinkNode) to handle direct data injection, saving, and payload-based I/O within pipelines.
• Update tests to validate the new I/O functionality in pipeline execution.