### PR TITLE
Improvements  in pipeline inspection

### DIFF
--- a/semantiva/data_processors/data_slicer_factory.py
+++ b/semantiva/data_processors/data_slicer_factory.py
@@ -82,6 +82,7 @@ class SlicingDataProcessorFactory:
 
                 @classmethod
                 def input_data_type(cls):
+                    """Returns the input data type."""
                     return cls.input_data_type_override
 
                 def process(
@@ -95,7 +96,7 @@ class SlicingDataProcessorFactory:
                     """
 
                     probed_results = []
-                    for idx, data_item in enumerate(data):
+                    for data_item in data:
                         probed_results.append(
                             super().process(data_item, *args, **kwargs)
                         )

--- a/semantiva/data_processors/data_slicer_factory.py
+++ b/semantiva/data_processors/data_slicer_factory.py
@@ -1,6 +1,10 @@
 from typing import Type
 from semantiva.data_types.data_types import DataCollectionType
-from semantiva.data_processors.data_processors import DataOperation, DataProbe
+from semantiva.data_processors.data_processors import (
+    BaseDataProcessor,
+    DataOperation,
+    DataProbe,
+)
 
 
 class SlicingDataProcessorFactory:
@@ -10,7 +14,8 @@ class SlicingDataProcessorFactory:
 
     @staticmethod
     def create(
-        processor_class: Type, input_data_collection_type: Type[DataCollectionType]
+        processor_class: Type[BaseDataProcessor],
+        input_data_collection_type: Type[DataCollectionType],
     ):
         """
         Creates a new processor class that slices data and manages context.
@@ -31,7 +36,7 @@ class SlicingDataProcessorFactory:
                 processor_class.input_data_type() == processor_class.output_data_type()
             ), "Data slicing supported only for processors matching input and output data types."
 
-            class SlicingDataOperator(processor_class):
+            class SlicingDataOperator(processor_class):  # type: ignore[valid-type, misc]
                 """
                 Wraps a data operator to handle data slicing.
                 """
@@ -68,7 +73,7 @@ class SlicingDataProcessorFactory:
 
         elif issubclass(processor_class, DataProbe):
 
-            class SlicingDataProbe(processor_class):
+            class SlicingDataProbe(processor_class):  # type: ignore[valid-type, misc]
                 """
                 Wraps a data probe to handle data slicing.
                 """

--- a/semantiva/data_processors/data_slicer_factory.py
+++ b/semantiva/data_processors/data_slicer_factory.py
@@ -107,6 +107,9 @@ class SlicingDataProcessorFactory:
             return SlicingDataProbe
 
 
-def Slicer(processor_cls: Type, input_data_collection_type: Type[DataCollectionType]):
+def Slicer(
+    processor_cls: Type[BaseDataProcessor],
+    input_data_collection_type: Type[DataCollectionType],
+):
     """Convenient user API for creating slicer nodes with explicit types."""
     return SlicingDataProcessorFactory.create(processor_cls, input_data_collection_type)

--- a/semantiva/exceptions/pipeline.py
+++ b/semantiva/exceptions/pipeline.py
@@ -1,0 +1,17 @@
+# Description: Custom exceptions for the semantiva package.
+
+
+class PipelineConfigurationError(Exception):
+    """Raised when the pipeline configuration is invalid."""
+
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+
+class PipelineTopologyError(Exception):
+    """Raised when the pipeline topology is invalid."""
+
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -252,6 +252,15 @@ class Pipeline(PayloadProcessor):
     def inspect(self) -> str:
         """
         Return a comprehensive summary of the pipeline's structure.
+        The summary covers:
+            • Node details: The class names of the nodes and their operations.
+            • Parameters: Which parameters come from the pipeline configuration versus the
+                        context.
+            • Context updates: The keywords that each node creates or modifies in the context.
+            • Required context keys: The set of context parameters necessary for the pipeline.
+            • Execution time: The pipeline's cumulative execution time, tracked by the StopWatch.
+        Returns:
+            str: A formatted report describing the pipeline composition and relevant details.
         """
         summary_lines = ["Pipeline Structure:"]
         # All context keys required by the pipeline

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -154,14 +154,7 @@ class Pipeline(PayloadProcessor):
             # Get the expected input type for the node's operation
             input_type = node.processor.input_data_type()
 
-            if (
-                isinstance(result_data, input_type)
-                or (
-                    isinstance(result_data, DataCollectionType)
-                    and input_type == result_data.collection_base_type()
-                )
-                or (issubclass(type(result_data), input_type))
-            ):
+            if issubclass(type(result_data), input_type):
                 result_data, result_context = node.process(result_data, result_context)
 
             # Case 2: Incompatible data type

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -1,13 +1,8 @@
-<<<<<<< HEAD
 from typing import Any, Dict, List, Optional, Tuple
-=======
-from typing import Any, Dict, List, Optional, Tuple, Type
 from semantiva.exceptions.pipeline import (
     PipelineConfigurationError,
     PipelineTopologyError,
 )
-from .stop_watch import StopWatch
->>>>>>> 9ff7272 (Fixed bug in pipeline inspection. Added key supression and custom exceptions for pipeline)
 from .payload_processors import PayloadProcessor
 from .nodes.nodes import (
     PipelineNode,
@@ -220,9 +215,6 @@ class Pipeline(PayloadProcessor):
             # Get the expected input type for the node's operation
             input_type = node.processor.input_data_type()
 
-<<<<<<< HEAD
-            if issubclass(type(result_data), input_type):
-=======
             if (
                 isinstance(result_data, input_type)
                 or (
@@ -231,7 +223,6 @@ class Pipeline(PayloadProcessor):
                 )
                 or (issubclass(type(result_data), input_type))
             ):
->>>>>>> 9ff7272 (Fixed bug in pipeline inspection. Added key supression and custom exceptions for pipeline)
                 result_data, result_context = node.process(result_data, result_context)
 
             # Case 2: Incompatible data type

--- a/tests/test_pipeline_and_slicing.py
+++ b/tests/test_pipeline_and_slicing.py
@@ -4,6 +4,7 @@ from semantiva.context_processors.context_types import (
     ContextCollectionType,
 )
 from semantiva.payload_operations import Pipeline
+from semantiva.exceptions.pipeline import PipelineTopologyError
 from .test_utils import (
     FloatDataType,
     FloatDataCollection,
@@ -243,7 +244,7 @@ def test_image_pipeline_invalid_configuration():
     ]
 
     # Check that initializing the pipeline raises an AssertionError
-    with pytest.raises(AssertionError):
+    with pytest.raises(PipelineTopologyError):
         _ = Pipeline(node_configurations)
 
 


### PR DESCRIPTION
This PR fixes a bug in the pipeline inspection algorithm where required parameters were incorrectly determined when renaming or deleting keys. The issue arose because the algorithm did not track suppressed keys. This has been fixed by ensuring that if a required key has been deleted, the pipeline configuration is checked to determine if the key is not provided. If not, a `PipelineConfigurationError` is raised.

Additionally, a new exception, `PipelineTopologyError`, has been introduced for cases where the pipeline topology check fails.

The pipeline inspection logic has also been refactored into smaller, more manageable methods to improve maintainability. However, further refactoring will be postponed until [Issue-28](https://github.com/semantiva/Semantiva-board/issues/28) , which introduces changes to pipeline topology checks.

### Additions

* New exceptions module to provide custom exceptions:
* Added `PipelineConfigurationError` (raised when a required key is missing from the configuration).
* Added `PipelineTopologyError` (raised when topology validation fails).
* This module allows for future expansion with more specialized exceptions for nodes, operations, etc.

### Changes

- Fixed: Pipeline inspection now properly tracks suppressed keys.
- Fixed: Bug in inspection when renaming context parameters.
- Added: `_validate_deleted_keys` (private method to check if a node requires a previously deleted key that is not provided in the pipeline configuration).
- Refactored: Split the pipeline inspection logic into smaller private methods to enhance maintainability and readability.


### Examples 

Consider the following pipeline configuration:

![image](https://github.com/user-attachments/assets/7bef1efe-4cf7-4fd8-847a-139f7900d826)
The inspect output will be:

`

Pipeline Structure:
	Required context keys: None

	1. Node: ImageAddition (OperationNode)
		Parameters: image_to_add
			From pipeline configuration: image_to_add=ImageDataType: (256, 256)
			From context: None
		Context additions: None

	2. Node: ImageSubtraction (OperationNode)
		Parameters: image_to_subtract
			From pipeline configuration: image_to_subtract=ImageDataType: (256, 256)
			From context: None
		Context additions: None

	3. Node: BasicImageProbe (ProbeContextInjectorNode)
		Parameters: None
			From pipeline configuration: None
			From context: None
		Context additions: None

	4. Node: BasicImageProbe (ProbeResultCollectorNode)
		Parameters: None
			From pipeline configuration: None
			From context: None
		Context additions: None

	5. Node: Rename_key1_to_key2 (ContextNode)
		Parameters: key1
			From pipeline configuration: None
			From context: key1
		Context additions: key2
		Context suppressions: key1

	6. Node: Delete_key2 (ContextNode)
		Parameters: key2
			From pipeline configuration: None
			From context: key2
		Context additions: None
		Context suppressions: key2


If we add a Node that requires 'key2' bellow the last node and provide the value in pipeline configuration:

`
Pipeline Structure:
	Required context keys: None

	1. Node: ImageAddition (OperationNode)
		Parameters: image_to_add
			From pipeline configuration: image_to_add=ImageDataType: (256, 256)
			From context: None
		Context additions: None

	2. Node: ImageSubtraction (OperationNode)
		Parameters: image_to_subtract
			From pipeline configuration: image_to_subtract=ImageDataType: (256, 256)
			From context: None
		Context additions: None

	3. Node: BasicImageProbe (ProbeContextInjectorNode)
		Parameters: None
			From pipeline configuration: None
			From context: None
		Context additions: None

	4. Node: BasicImageProbe (ProbeResultCollectorNode)
		Parameters: None
			From pipeline configuration: None
			From context: None
		Context additions: None

	5. Node: Rename_key1_to_key2 (ContextNode)
		Parameters: key1
			From pipeline configuration: None
			From context: key1
		Context additions: key2
		Context suppressions: key1

	6. Node: Delete_key2 (ContextNode)
		Parameters: key2
			From pipeline configuration: None
			From context: key2
		Context additions: None
		Context suppressions: key2

	7. Node: DummyImageProbe (ProbeResultCollectorNode)
		Parameters: key2
			From pipeline configuration: key2=1
			From context: None
		Context additions: None
`
If the DummyImageProbe does do provide key2 in the pipeline configuration:

`PipelineConfigurationError: Node 7 requires context keys previously deleted: {'key2'}`


 