### PR TITLE
Centralized stop_watch execution

### DIFF
--- a/semantiva/payload_operations/nodes/io_nodes.py
+++ b/semantiva/payload_operations/nodes/io_nodes.py
@@ -63,12 +63,12 @@ class DataSourceNode(DataNode):
         Returns:
             Tuple[BaseDataType, ContextType]: The processed data and updated context.
         """
-        self.stop_watch.start()
+
         # Save the current context to be used by the processor
         self.observer_context = context
         parameters = self._get_processor_parameters(self.observer_context)
         output_data = self.processor.process(data, **parameters)
-        self.stop_watch.stop()
+
         return output_data, self.observer_context
 
     def _execute_data_collection_context_collection(self, data_collection, context):
@@ -130,12 +130,12 @@ class PayloadSourceNode(DataNode):
         Returns:
             Tuple[BaseDataType, ContextType]: The processed data and updated context.
         """
-        self.stop_watch.start()
+
         # Save the current context to be used by the processor
         self.observer_context = context
         parameters = self._get_processor_parameters(self.observer_context)
         loaded_data, loaded_context = self.processor.process(data, **parameters)
-        self.stop_watch.stop()
+
         # Merge context and loaded_context
         for key, value in loaded_context.items():
             if key in context.keys():
@@ -202,12 +202,12 @@ class DataSinkNode(DataNode):
         Returns:
             Tuple[BaseDataType, ContextType]: The processed data and updated context.
         """
-        self.stop_watch.start()
+
         # Save the current context to be used by the processor
         self.observer_context = context
         parameters = self._get_processor_parameters(self.observer_context)
         output_data = self.processor.process(data, **parameters)
-        self.stop_watch.stop()
+
         return output_data, self.observer_context
 
     def _execute_data_collection_context_collection(self, data_collection, context):
@@ -269,12 +269,12 @@ class PayloadSinkNode(DataNode):
         Returns:
             Tuple[BaseDataType, ContextType]: The processed data and updated context.
         """
-        self.stop_watch.start()
+
         # Save the current context to be used by the processor
         self.observer_context = context
         parameters = self._get_processor_parameters(self.observer_context)
         output_data = self.processor.process(data, **parameters)
-        self.stop_watch.stop()
+
         return output_data, self.observer_context
 
     def _execute_data_collection_context_collection(self, data_collection, context):

--- a/semantiva/payload_operations/nodes/nodes.py
+++ b/semantiva/payload_operations/nodes/nodes.py
@@ -369,9 +369,9 @@ class ContextNode(PipelineNode):
         Returns:
             tuple[BaseDataType, ContextType]: A tuple containing the processed data and context.
         """
-        self.stop_watch.start()
+
         updated_context = self.processor.operate_context(context)
-        self.stop_watch.stop()
+
         return data, updated_context
 
 
@@ -425,12 +425,12 @@ class OperationNode(DataNode):
         Returns:
             Tuple[BaseDataType, ContextType]: The processed data and the updated context.
         """
-        self.stop_watch.start()
+
         # Save the current context to be used by the processor
         self.observer_context = context
         parameters = self._get_processor_parameters(self.observer_context)
         output_data = self.processor.process(data, **parameters)
-        self.stop_watch.stop()
+
         return output_data, self.observer_context
 
     def _execute_data_collection_single_context(
@@ -590,11 +590,11 @@ class ProbeContextInjectorNode(ProbeNode):
         Returns:
             Tuple[BaseDataType, ContextType]: The unchanged data and the updated context with the probe result.
         """
-        self.stop_watch.start()
+
         parameters = self._get_processor_parameters(context)
         probe_result = self.processor.process(data, **parameters)
         context.set_value(self.context_keyword, probe_result)
-        self.stop_watch.stop()
+
         return data, context
 
     def _execute_data_collection_single_context(

--- a/semantiva/payload_operations/payload_processors.py
+++ b/semantiva/payload_operations/payload_processors.py
@@ -4,6 +4,7 @@ from ..context_processors.context_types import ContextType
 from ..context_processors.context_observer import ContextObserver
 from ..data_types.data_types import BaseDataType, NoDataType
 from ..logger import Logger
+from ..payload_operations.stop_watch import StopWatch
 
 
 class PayloadProcessor(ContextObserver, ABC):
@@ -19,9 +20,11 @@ class PayloadProcessor(ContextObserver, ABC):
     """
 
     logger: Logger
+    stop_watch: StopWatch
 
     def __init__(self, logger: Optional[Logger] = None):
         super().__init__()
+        self.stop_watch = StopWatch()
         if logger:
             # If a logger instance is provided, use it
             self.logger = logger
@@ -59,4 +62,7 @@ class PayloadProcessor(ContextObserver, ABC):
         assert isinstance(
             context_, ContextType
         ), f"Context must be a dictionary of an instance of `ContextType`. Got {type(context)}"
-        return self._process(data, context_)
+        self.stop_watch.start()
+        payload_processor_result = self._process(data, context_)
+        self.stop_watch.stop()
+        return payload_processor_result

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, Optional, Tuple
-from .stop_watch import StopWatch
 from .payload_processors import PayloadProcessor
 from .nodes.nodes import (
     DataNode,
@@ -95,7 +94,6 @@ class Pipeline(PayloadProcessor):
 
     pipeline_configuration: List[Dict]
     nodes: List[DataNode]
-    stop_watch: StopWatch
 
     def __init__(
         self, pipeline_configuration: List[Dict], logger: Optional[Logger] = None
@@ -118,7 +116,6 @@ class Pipeline(PayloadProcessor):
         super().__init__(logger)
         self.nodes: List[DataNode] = []
         self.pipeline_configuration: List[Dict] = pipeline_configuration
-        self.stop_watch = StopWatch()
         self._initialize_nodes()
         if self.logger:
             self.logger.info(f"Initialized {self.__class__.__name__}")
@@ -211,7 +208,7 @@ class Pipeline(PayloadProcessor):
         Raises:
             TypeError: If the node's expected input type does not match the current data type.
         """
-        self.stop_watch.start()
+
         result_data, result_context = data, context
         self.logger.info("Start processing pipeline")
         for index, node in enumerate(self.nodes, start=1):
@@ -238,7 +235,7 @@ class Pipeline(PayloadProcessor):
                     f"Incompatible data type for Node {node.processor.__class__.__name__} "
                     f"expected {input_type}, but received {type(result_data)}."
                 )
-        self.stop_watch.stop()
+
         self.logger.info("Pipeline execution complete.")
         self.logger.debug(
             "Pipeline execution timing report: \n\tPipeline %s\n%s",


### PR DESCRIPTION
This small PR centralizes the StopWatch instantiation in PayloadProcessor base class, since all concrete classes instance their own. Also puts the start/stop of the watch in process method, unified for all processors. This will improve accuracy, because the timer will now take into account the slicing. 

### Changes
- StopWatch is initialized in `PayloadProcessor`
- Timer call is centralized in `process`, reducing multiple start/stop scattered through nodes
- Timer takes into account slicing, which is now part of Node logic.


