### PR TITLE
Added memory tracker prototype.

### DIFF
--- a/semantiva/payload_operations/memory_tracker.py
+++ b/semantiva/payload_operations/memory_tracker.py
@@ -1,0 +1,81 @@
+# Description: A memory tracker class to measure peak memory usage.
+import threading
+import psutil
+
+
+class MemoryTracker:
+    """A memory tracker class to measure peak memory usage.
+    When the tracker is started, it will pool the memory usage at regular intervals
+    in a separate thread."""
+
+    _peak_memory: int
+    _pooling_interval: float
+    _running: bool
+    _thread: threading.Thread
+    _stop_event: threading.Event
+    _calls: int
+
+    def __init__(self, pooling_interval: float = 0.001):
+        """
+        Initialize the memory tracker.
+
+        Args:
+            pooling_interval (float): The interval in seconds between memory checks.
+        """
+        self._pooling_interval = pooling_interval
+        self._stop_event = threading.Event()
+        self.reset()
+
+    def _measure_memory(self):
+        """Measure the current memory usage."""
+        return psutil.Process().memory_info().rss
+
+    def _pool_memory(self):
+        """Pool the memory usage at regular intervals."""
+        while self._running:
+            current_memory = self._measure_memory()
+            self._peak_memory = max(self._peak_memory, current_memory)
+            # Interruptible wait instead of sleep
+            self._stop_event.wait(timeout=self._pooling_interval)
+
+    def start(self):
+        """Start the memory tracker."""
+        if not self._running:
+            self._running = True
+            # Initial memory measurement
+            self._peak_memory = self._measure_memory()
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._pool_memory)
+            self._thread.start()
+            self._calls += 1
+
+    def stop(self):
+        """Stop the memory tracker and perform a final memory check."""
+        if self._running:
+            # Final immediate memory check before joining
+            final_memory = self._measure_memory()
+            self._peak_memory = max(self._peak_memory, final_memory)
+
+            self._running = False
+            self._stop_event.set()  # Immediately interrupt waiting
+            self._thread.join()
+
+    def reset(self):
+        """Reset the memory tracker by clearing all values."""
+        self._peak_memory = 0
+        self._running = False
+        self._thread = None
+        self._stop_event.clear()
+        self._calls = 0
+
+    def set_pooling_interval(self, pooling_interval: float):
+        """Set the pooling interval for memory checks."""
+        self._pooling_interval = pooling_interval
+
+    def peak_memory(self):
+        """Return the peak memory usage."""
+        return self._peak_memory
+
+    def peak_memory_mb(self):
+        """Return the peak memory usage in megabytes (MiB)."""
+        return self._peak_memory / (1024 * 1024)

--- a/semantiva/payload_operations/payload_processors.py
+++ b/semantiva/payload_operations/payload_processors.py
@@ -5,6 +5,7 @@ from ..context_processors.context_observer import ContextObserver
 from ..data_types.data_types import BaseDataType, NoDataType
 from ..logger import Logger
 from ..payload_operations.stop_watch import StopWatch
+from ..payload_operations.memory_tracker import MemoryTracker
 
 
 class PayloadProcessor(ContextObserver, ABC):
@@ -21,10 +22,12 @@ class PayloadProcessor(ContextObserver, ABC):
 
     logger: Logger
     stop_watch: StopWatch
+    memory_tracker: MemoryTracker
 
     def __init__(self, logger: Optional[Logger] = None):
         super().__init__()
         self.stop_watch = StopWatch()
+        self.memory_tracker = MemoryTracker()
         if logger:
             # If a logger instance is provided, use it
             self.logger = logger
@@ -63,6 +66,8 @@ class PayloadProcessor(ContextObserver, ABC):
             context_, ContextType
         ), f"Context must be a dictionary of an instance of `ContextType`. Got {type(context)}"
         self.stop_watch.start()
+        self.memory_tracker.start()
         payload_processor_result = self._process(data, context_)
         self.stop_watch.stop()
+        self.memory_tracker.stop()
         return payload_processor_result

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -238,9 +238,9 @@ class Pipeline(PayloadProcessor):
 
         self.logger.info("Pipeline execution complete.")
         self.logger.debug(
-            "Pipeline execution timing report: \n\tPipeline %s\n%s",
+            "Pipeline execution report: \n\tPipeline %s\n%s",
             str(self.stop_watch),
-            self.get_timers(),
+            self.tracker_summary(),
         )
         return result_data, result_context
 
@@ -323,6 +323,18 @@ class Pipeline(PayloadProcessor):
             f"\t\tNode {i + 1}: {type(node.processor).__name__}; "
             f"\tElapsed CPU Time: {node.stop_watch.elapsed_cpu_time():.6f}s; "
             f"\tElapsed Wall Time: {node.stop_watch.elapsed_wall_time():.6f}s"
+            for i, node in enumerate(self.nodes)
+        ]
+        return "\n".join(timer_info)
+
+    def tracker_summary(self) -> str:
+        """
+        Retrieve time and memory tracking information for each node's execution"""
+        timer_info = [
+            f"\t\tNode {i + 1}: {type(node.processor).__name__}; "
+            f"\tElapsed CPU Time: {node.stop_watch.elapsed_cpu_time():.6f}s; "
+            f"\tElapsed Wall Time: {node.stop_watch.elapsed_wall_time():.6f}s; "
+            f"\tPeak Memory: {node.memory_tracker.peak_memory_mb():.6f} MB"
             for i, node in enumerate(self.nodes)
         ]
         return "\n".join(timer_info)


### PR DESCRIPTION
This PR will be updated with suggestions and potentially with a `PerformanceManager` class that will hold Memory and Timer trackers instances and handle the enable/disable of trackers.

The aim of this PR is to show the partial results before going to the final solution 


### Addition
- `MemoryTracker` class that  measure peak memory usage.
    When the tracker is started, it will pool the memory usage at regular intervals
    in a separate thread.
    
- Integration in PayloadProcessor `process` method in the same logic as the Timer Tracker

An example of output using a big stack (100,1000,1000), that explains the high memory

================================Pipeline Execution Summary================================
                Node 1: StackToImageMeanProjector;      Elapsed CPU Time: 0.158429s;    Elapsed Wall Time: 0.112446s;   Peak Memory: 837.468750 MB
                Node 2: ImageAddition;  Elapsed CPU Time: 0.004905s;    Elapsed Wall Time: 0.003813s;   Peak Memory: 845.136719 MB
                Node 3: ImageSubtraction;       Elapsed CPU Time: 0.007298s;    Elapsed Wall Time: 0.005455s;   Peak Memory: 845.160156 MB
                Node 4: ImageCropper;   Elapsed CPU Time: 0.000925s;    Elapsed Wall Time: 0.000708s;   Peak Memory: 837.601562 MB
===============================================================================

