### PR TITLE
Refactor context processor integration and metadata architecture for semantic introspection

### DIFF
--- a/semantiva/component_loader/component_loader.py
+++ b/semantiva/component_loader/component_loader.py
@@ -44,34 +44,40 @@ def context_renamer_factory(original_key: str, destination_key: str):
             self.logger.warning(f"Key '{original_key}' not found in context.")
         return context
 
-    def get_required_keys(self) -> List[str]:
+    def get_required_keys(cls) -> List[str]:
         """
         Return a list containing the original key, as it is required for renaming.
         """
         return [original_key]
 
-    def get_created_keys(self) -> List[str]:
+    def get_created_keys(cls) -> List[str]:
         """
         Return a list containing the new key, which is created as a result of renaming.
         """
         return [destination_key]
 
-    def get_suppressed_keys(self) -> List[str]:
+    def get_suppressed_keys(cls) -> List[str]:
         """
         Return a list containing the original key, since it is suppressed after renaming.
         """
         return [original_key]
 
-    # Define the class attributes and methods in a dictionary
-    class_attrs = {
-        "_process_logic": _process_logic,
-        "get_required_keys": get_required_keys,
-        "get_created_keys": classmethod(get_created_keys),
-        "get_suppressed_keys": get_suppressed_keys,
-    }
-
     # Create a dynamic class name that clearly shows the renaming transformation
     dynamic_class_name = f"Rename_{original_key}_to_{destination_key}"
+
+    # Define the class attributes and methods in a dictionary
+    class_attrs = {
+        # "__name__": dynamic_class_name,
+        "_process_logic": _process_logic,
+        "get_required_keys": classmethod(get_required_keys),
+        "get_created_keys": classmethod(get_created_keys),
+        "get_suppressed_keys": classmethod(get_suppressed_keys),
+    }
+
+    # Add docstring to the dynamically generated class
+    class_attrs["__doc__"] = (
+        f"Renames context key '{original_key}' to '{destination_key}'."
+    )
 
     # Create and return the dynamically named class that inherits from ContextProcessor.
     return type(dynamic_class_name, (ContextProcessor,), class_attrs)
@@ -106,19 +112,19 @@ def context_deleter_factory(key: str):
             self.logger.warning(f"Unable to delete non-existing '{key}' from context.")
         return context
 
-    def get_required_keys(self) -> List[str]:
+    def get_required_keys(cls) -> List[str]:
         """
         Return a list with the key to delete, indicating it is required.
         """
         return [key]
 
-    def get_created_keys(self) -> List[str]:
+    def get_created_keys(cls) -> List[str]:
         """
         This operation does not create any keys.
         """
         return []
 
-    def get_suppressed_keys(self) -> List[str]:
+    def get_suppressed_keys(cls) -> List[str]:
         """
         Return a list containing the key that is deleted.
         """
@@ -134,6 +140,9 @@ def context_deleter_factory(key: str):
 
     # Create a dynamic class name
     dynamic_class_name = f"Delete_{key}"
+
+    # Add docstring to the dynamically generated class
+    class_attrs["__doc__"] = f"Deletes context key '{key}'."
 
     # Create and return the dynamically named class that inherits from ContextProcessor.
     return type(dynamic_class_name, (ContextProcessor,), class_attrs)

--- a/semantiva/context_processors/context_processors.py
+++ b/semantiva/context_processors/context_processors.py
@@ -3,15 +3,13 @@ from typing import List, Optional, Union
 from semantiva.context_processors.context_types import ContextType
 from semantiva.workflows.fitting_model import FittingModel
 from semantiva.data_types.data_types import BaseDataType
+from semantiva.core import SemantivaObject
 from semantiva.logger import Logger
 
 
-class ContextProcessor(ABC):
+class ContextProcessor(SemantivaObject):
     """
-    Abstract base class for defining operations on a context.
-
-    This class serves as a foundation for implementing specific operations
-    that manipulate or utilize the context in various ways.
+    Base class for performing context operations.
     """
 
     logger: Logger
@@ -95,6 +93,23 @@ class ContextProcessor(ABC):
 
     def __str__(self):
         return f"{self.__class__.__name__}"
+
+    @classmethod
+    def _define_metadata(cls):
+        excluded_parameters = ["cls", "self", "data"]
+
+        annotated_parameter_list = [
+            f"{param_name}: {param_type}"
+            for param_name, param_type in cls._retrieve_parameter_signatures(
+                cls._process_logic, excluded_parameters
+            )
+        ]
+
+        component_metadata = {
+            "component_type": "ContextProcessor",
+            "input_parameters": annotated_parameter_list or "None",
+        }
+        return component_metadata
 
 
 class ModelFittingContextProcessor(ContextProcessor):

--- a/semantiva/core/semantiva_object.py
+++ b/semantiva/core/semantiva_object.py
@@ -86,7 +86,6 @@ class SemantivaObject(ABC):
                 for item in value:
                     lines.append(f"      - {item}")
             else:
-
                 lines.append(f" - {key}: {value}")
 
         # Handle wrapped processor docstring separately if present

--- a/semantiva/data_processors/__init__.py
+++ b/semantiva/data_processors/__init__.py
@@ -1,1 +1,16 @@
-from .data_processors import *
+from .data_processors import (
+    DataOperation,
+    DataProbe,
+    BaseDataProcessor,
+    OperationTopologyFactory,
+)
+from .data_slicer_factory import Slicer
+
+
+__all__ = [
+    "DataOperation",
+    "DataProbe",
+    "BaseDataProcessor",
+    "OperationTopologyFactory",
+    "Slicer",
+]

--- a/semantiva/data_processors/data_slicer_factory.py
+++ b/semantiva/data_processors/data_slicer_factory.py
@@ -69,13 +69,16 @@ class SlicingDataProcessorFactory:
                     return processed_data
 
             SlicingDataOperator.__name__ = class_name
+            SlicingDataOperator.__doc__ = (
+                f"{SlicingDataOperator.__doc__} Wraps {processor_class.__doc__}"
+            )
             return SlicingDataOperator
 
         elif issubclass(processor_class, DataProbe):
 
             class SlicingDataProbe(processor_class):  # type: ignore[valid-type, misc]
                 """
-                Wraps a data probe to handle data slicing.
+                Data slicer probe.
                 """
 
                 input_data_type_override = input_data_collection_type
@@ -104,6 +107,10 @@ class SlicingDataProcessorFactory:
                     return probed_results
 
             SlicingDataProbe.__name__ = class_name
+
+            SlicingDataProbe.__doc__ = (
+                f"{SlicingDataProbe.__doc__} Wraps {processor_class.__doc__}"
+            )
             return SlicingDataProbe
 
 

--- a/semantiva/payload_operations/__init__.py
+++ b/semantiva/payload_operations/__init__.py
@@ -1,7 +1,7 @@
 from .nodes.node_factory import node_factory
 from .payload_processors import PayloadProcessor
 from .pipeline import Pipeline
-from .nodes.nodes import DataNode, ProbeNode, PipelineNode, ContextNode
+from .nodes.nodes import DataNode, ProbeNode, PipelineNode
 
 __all__ = [
     "node_factory",
@@ -11,5 +11,4 @@ __all__ = [
     "ProbeNode",
     "StopWatch",
     "PipelineNode",
-    "ContextNode",
 ]

--- a/semantiva/payload_operations/nodes/__init__.py
+++ b/semantiva/payload_operations/nodes/__init__.py
@@ -1,8 +1,7 @@
-from .nodes import DataNode, ProbeNode, PipelineNode, ContextNode
+from .nodes import DataNode, ProbeNode, PipelineNode
 
 __all__ = [
     "DataNode",
     "ProbeNode",
     "PipelineNode",
-    "ContextNode",
 ]

--- a/semantiva/payload_operations/nodes/node_factory.py
+++ b/semantiva/payload_operations/nodes/node_factory.py
@@ -936,7 +936,7 @@ class NodeFactory:
                     "ContextProcessor": processor_.__name__,
                     "processor_docstring": processor_.get_metadata().get("docstring"),
                     "get_required_context_keys": cls.get_required_keys() or "None",
-                    "get_supressed_context_keys": cls.get_suppressed_keys() or "None",
+                    "get_suppressed_context_keys": cls.get_suppressed_keys() or "None",
                     "get_created_context_keys": cls.get_created_keys() or "None",
                 }
                 return component_metadata

--- a/semantiva/payload_operations/nodes/node_factory.py
+++ b/semantiva/payload_operations/nodes/node_factory.py
@@ -37,7 +37,7 @@ class NodeFactory:
             logger (Optional[Logger]): Optional logger instance for diagnostic messages.
 
         Returns:
-            PipelineNode: An instance of a subclass of DataNode or PipelineNode.
+            PipelineNode: A subclass of PipelineNode.
 
         Raises:
             ValueError: If the node definition is invalid or if the processor type is unsupported.

--- a/semantiva/payload_operations/nodes/node_factory.py
+++ b/semantiva/payload_operations/nodes/node_factory.py
@@ -5,10 +5,6 @@ from semantiva.data_processors import DataOperation, DataProbe
 from semantiva.data_types import BaseDataType, NoDataType
 from semantiva.component_loader import ComponentLoader
 from semantiva.logger import Logger
-from .nodes import (
-    DataNode,
-    ContextNode,
-)
 from semantiva.context_processors import (
     ContextType,
     ContextCollectionType,
@@ -18,8 +14,8 @@ from semantiva.context_processors import (
 from semantiva.logger import Logger
 from .nodes import (
     DataNode,
-    ContextNode,
     ProbeNode,
+    PipelineNode,
 )
 
 
@@ -32,7 +28,7 @@ class NodeFactory:
     def create_io_node(
         node_definition: Dict,
         logger: Optional[Logger] = None,
-    ) -> DataNode | ContextNode:
+    ) -> PipelineNode:
         """
         Factory function to create an appropriate data I/O node instance based on the given definition.
 
@@ -41,7 +37,7 @@ class NodeFactory:
             logger (Optional[Logger]): Optional logger instance for diagnostic messages.
 
         Returns:
-            DataNode | ContextNode: An instance of a subclass of DataNode or ContextNode.
+            PipelineNode: An instance of a subclass of DataNode or PipelineNode.
 
         Raises:
             ValueError: If the node definition is invalid or if the processor type is unsupported.
@@ -833,12 +829,129 @@ class NodeFactory:
             logger=logger,
         )
 
+    @staticmethod
+    def create_context_processor_node(logger, processor_, parameters):
+
+        context_processor_instance = processor_(logger, **parameters)
+
+        class ContextProcessorNode(PipelineNode):
+            """
+            A node that wrapps a context processor.
+            """
+
+            processor = processor_
+
+            def __init__(
+                self,
+                processor_config: Optional[Dict] = None,
+                logger: Optional[Logger] = None,
+            ):
+                """
+                Initialize a Node with the specified context processor, and parameters.
+
+                Args:
+                    processor (Type[ContextProcessor]): The class of the context processor associated with this node.
+                    processor_config (Optional[Dict]): Operation parameters. Defaults to None.
+                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
+                """
+                super().__init__(logger)
+                self.logger.debug(
+                    f"Initializing {self.__class__.__name__} ({processor_.__name__})"
+                )
+                processor_config = processor_config or {}
+                self.processor = processor_(logger, **processor_config)
+                self.processor_config = processor_config
+
+            def __str__(self) -> str:
+                """
+                Return a string representation of the node.
+
+                Returns:
+                    str: A string summarizing the node's attributes and execution summary.
+                """
+                class_name = self.__class__.__name__
+                return (
+                    f"{class_name}(\n"
+                    f"     processor={self.processor},\n"
+                    f"     processor_config={self.processor_config},\n"
+                    f"     Execution summary: {self.stop_watch}\n"
+                    f")"
+                )
+
+            @classmethod
+            def get_created_keys(cls) -> List[str]:
+                """
+                Retrieve a list of context keys that will be created by the processor.
+
+                Returns:
+                    List[str]: A list of context keys that the processor will add or modify during its execution.
+                """
+
+                return context_processor_instance.get_created_keys()
+
+            @classmethod
+            def get_required_keys(cls) -> List[str]:
+                """
+                Retrieve a list of context keys required by the processor.
+
+                Returns:
+                    List[str]: A list of context keys.
+                """
+                return context_processor_instance.get_required_keys()
+
+            @classmethod
+            def get_suppressed_keys(cls) -> List[str]:
+                """
+                Retrieve a list of context keys that will be removed by the processor.
+
+                Returns:
+                    List[str]: A list of context keys that the processor will remove during its execution.
+                """
+                return context_processor_instance.get_suppressed_keys()
+
+            def _process(
+                self, data: BaseDataType, context: ContextType
+            ) -> tuple[BaseDataType, ContextType]:
+                """
+                Processes the given data and context.
+
+                Args:
+                    data (BaseDataType): The data to be processed.
+                    context (ContextType): The context in which the data is processed.
+
+                Returns:
+                    tuple[BaseDataType, ContextType]: A tuple containing the processed data and context.
+                """
+
+                updated_context = self.processor.operate_context(context)
+
+                return data, updated_context
+
+            @classmethod
+            def _define_metadata(cls):
+
+                # Define the metadata for the ContextProcessorNode
+                component_metadata = {
+                    "component_type": "ContextProcessorNode",
+                    "ContextProcessor": processor_.__name__,
+                    "processor_docstring": processor_.get_metadata().get("docstring"),
+                    "get_required_context_keys": cls.get_required_keys() or "None",
+                    "get_supressed_context_keys": cls.get_suppressed_keys() or "None",
+                    "get_created_context_keys": cls.get_created_keys() or "None",
+                }
+                return component_metadata
+
+        return ContextProcessorNode(
+            parameters,
+            logger=logger,
+        )
+
 
 # Main node factory function
 def node_factory(
     node_definition: Dict,
     logger: Optional[Logger] = None,
-) -> DataNode | ContextNode:
+) -> PipelineNode:
     """
     Factory function to create an appropriate node instance based on the given definition.
 
@@ -852,7 +965,7 @@ def node_factory(
         logger (Optional[Logger]): Optional logger instance for diagnostic messages.
 
     Returns:
-        DataNode | ContextNode: An instance of a subclass of DataNode or ContextNode.
+        PipelineNode: An instance of a subclass of DataNode or ContextProcessorNode.
 
     Raises:
         ValueError: If the node definition is invalid or if the processor type is unsupported.
@@ -875,7 +988,7 @@ def node_factory(
         raise ValueError("processor must be a class type or a string, not None.")
 
     if issubclass(processor, ContextProcessor):
-        return ContextNode(processor, processor_config=parameters, logger=logger)
+        return NodeFactory.create_context_processor_node(logger, processor, parameters)
 
     elif issubclass(processor, DataOperation):
         if context_keyword is not None:

--- a/semantiva/payload_operations/nodes/nodes.py
+++ b/semantiva/payload_operations/nodes/nodes.py
@@ -22,7 +22,6 @@ class PipelineNode(PayloadProcessor):
 
     processor: BaseDataProcessor | ContextProcessor
     processor_config: Dict
-    stop_watch: StopWatch
     logger: Logger
 
 
@@ -194,102 +193,6 @@ class DataNode(PipelineNode):
                 f"Incompatible data type for Node {self.processor.__class__.__name__} "
                 f"expected {input_type}, but received {type(result_data)}."
             )
-
-
-class ContextNode(PipelineNode):
-    """
-    Represents a node in the semantic framework.
-
-    A ContextNode is associated with a context processor and acts as a fundamental unit
-    in processing pipelines or networks.
-
-    Attributes:
-        processor (ContextProcessor): The context processor associated with the node.
-        processor_config (Dict): Configuration parameters for the context processor.
-        stop_watch (StopWatch): Tracks the execution time of the node's processor.
-        logger (Logger): Logger instance for diagnostic messages.
-    """
-
-    processor: ContextProcessor
-
-    def __init__(
-        self,
-        processor: Type[ContextProcessor],
-        processor_config: Optional[Dict] = None,
-        logger: Optional[Logger] = None,
-    ):
-        """
-        Initialize a Node with the specified context processor, and parameters.
-
-        Args:
-            processor (Type[ContextProcessor]): The class of the context processor associated with this node.
-            processor_config (Optional[Dict]): Operation parameters. Defaults to None.
-            logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-        """
-        super().__init__(logger)
-        self.logger.debug(
-            f"Initializing {self.__class__.__name__} ({processor.__name__})"
-        )
-        processor_config = processor_config or {}
-        self.processor = (
-            processor(logger, **processor_config)
-            if issubclass(processor, (DataOperation, ContextProcessor))
-            else processor(logger=logger)
-        )
-        self.processor_config = processor_config
-
-    def __str__(self) -> str:
-        """
-        Return a string representation of the node.
-
-        Returns:
-            str: A string summarizing the node's attributes and execution summary.
-        """
-        class_name = self.__class__.__name__
-        return (
-            f"{class_name}(\n"
-            f"     processor={self.processor},\n"
-            f"     processor_config={self.processor_config},\n"
-            f"     Execution summary: {self.stop_watch}\n"
-            f")"
-        )
-
-    def get_created_keys(self) -> List[str]:
-        """
-        Retrieve a list of context keys that will be created by the processor.
-
-        Returns:
-            List[str]: A list of context keys that the processor will add or create
-                       as a result of execution.
-        """
-        return self.processor.get_created_keys()
-
-    def _process(
-        self, data: BaseDataType, context: ContextType
-    ) -> tuple[BaseDataType, ContextType]:
-        """
-        Processes the given data and context.
-
-        Args:
-            data (BaseDataType): The data to be processed.
-            context (ContextType): The context in which the data is processed.
-
-        Returns:
-            tuple[BaseDataType, ContextType]: A tuple containing the processed data and context.
-        """
-
-        updated_context = self.processor.operate_context(context)
-
-        return data, updated_context
-
-    @classmethod
-    def _define_metadata(cls):
-
-        # Define the metadata for the ContextNode
-        component_metadata = {
-            "component_type": "ContextNode",
-        }
-        return component_metadata
 
 
 class ProbeNode(DataNode):

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any, Dict, List, Optional, Tuple
 from semantiva.exceptions.pipeline import (
     PipelineConfigurationError,
@@ -11,7 +12,6 @@ from .nodes.node_factory import node_factory
 from .nodes.nodes import (
     PipelineNode,
     DataNode,
-    ContextNode,
 )
 
 
@@ -190,8 +190,9 @@ class Pipeline(PayloadProcessor):
             f"\t\tContext additions: {self._format_set(created_keys)}",
         ]
 
-        # Add context suppressions if the node is a ContextNode
-        if isinstance(node, ContextNode):
+        # Add context suppressions if the node is a ContextProcessorNode
+        if node.get_metadata().get("component_type") == "ContextProcessorNode":
+            assert hasattr(node.processor, "get_suppressed_keys")
             suppressed_keys = node.processor.get_suppressed_keys()
             deleted_keys.update(suppressed_keys)
             node_summary_lines.append(
@@ -296,8 +297,8 @@ class Pipeline(PayloadProcessor):
             self.logger.info(f"Initialized Node {index}: {type(node).__name__}")
             nodes.append(node)
 
-            # Skip type consistency check for `ContextNode`
-            if isinstance(node, ContextNode):
+            # Skip type consistency check for `ContextProcessorNode`
+            if node.get_metadata().get("component_type") == "ContextProcessorNode":
                 continue
 
             # Perform type consistency check
@@ -325,3 +326,105 @@ class Pipeline(PayloadProcessor):
             "component_type": "Pipeline",
         }
         return component_metadata
+
+    def _print_nodes_semantic_ids(self):
+        """
+        Print the semantic ID of each node in the pipeline.
+
+        This method is used for debugging purposes to print the semantic ID of each node
+        in the pipeline.
+        """
+
+        print("Pipeline inspection:")
+        print(self.inspect())
+        print()
+        for index, node in enumerate(self.nodes, start=1):
+            print(f"\nNode {index}")
+            print(node.semantic_id())
+
+    def extended_inspection(self) -> str:
+        """
+        Provides a highly verbose and detailed pipeline inspection, suitable for advanced
+        debugging and LLM-based introspection. Each node includes detailed descriptions,
+        docstrings (provided as footnotes), parameter sources, and context operations.
+
+        Returns:
+            str: An extended inspection report of the pipeline.
+        """
+        summary_lines = ["Extended Pipeline Inspection:"]
+        footnotes: Dict[str, str] = {}
+
+        for index, node in enumerate(self.nodes, start=1):
+            injected_keys = set()
+            required_context_keys: set[str] = set()
+            created_context_keys: set[str] = set()
+            metadata = node.get_metadata()
+            processor = node.processor
+            node_class_name = node.__class__.__name__
+            processor_class_name = processor.__class__.__name__
+
+            required_keys = set()
+            if hasattr(processor, "get_required_context_keys"):
+                required_keys = set(processor.get_required_context_keys())
+            required_context_keys.update(required_keys)
+
+            if hasattr(processor, "get_required_keys"):
+                required_keys = set(processor.get_required_keys())
+                required_context_keys.update(required_keys)
+
+            suppressed_keys = set()
+            if hasattr(processor, "get_suppressed_keys"):
+                suppressed_keys = set(processor.get_suppressed_keys())
+
+            created_keys = set()
+            if hasattr(processor, "get_created_keys"):
+                created_keys = set(processor.get_created_keys())
+                created_context_keys.update(created_keys)
+
+            if metadata.get("component_type") == "ProbeContextInjectorNode":
+                injected_key = getattr(node, "context_keyword", None)
+                if injected_key:
+                    injected_keys = {injected_key}
+                    created_context_keys.add(injected_key)
+
+            processor_config = node.processor_config
+            config_params_str = (
+                ", ".join(f"{k}={v}" for k, v in processor_config.items())
+                if processor_config
+                else "None"
+            )
+
+            # Prepare detailed node summary
+            summary_lines.extend(
+                [
+                    f"\nNode {index}: {processor_class_name} ({node_class_name})",
+                    f"    - Component type: {metadata.get('component_type')}",
+                    f"    - Input data type: {node.input_data_type().__name__ if hasattr(node, 'input_data_type') else 'None'}",
+                    f"    - Output data type: {node.output_data_type().__name__ if hasattr(node, 'output_data_type') else 'None'}",
+                    f"    - Parameters from pipeline configuration: {config_params_str}",
+                    f"    - Parameters from context: {', '.join(required_keys) if required_keys else 'None'}",
+                    f"    - Context additions: {', '.join(created_keys | injected_keys ) or 'None'}",
+                    f"    - Context suppressions: {', '.join(suppressed_keys) if suppressed_keys else 'None'}",
+                ]
+            )
+
+            # Add detailed descriptions to footnotes
+            footnote_key = f"{processor_class_name}"
+            if footnote_key not in footnotes:
+                processor_doc = (
+                    inspect.getdoc(processor.__class__) or "No description provided."
+                )
+                footnotes[footnote_key] = processor_doc
+
+        required_final_keys = required_context_keys - created_context_keys
+        summary_lines.insert(
+            1,
+            f"    Required context keys: {', '.join(sorted(required_final_keys)) or 'None'}",
+        )
+
+        # Append footnotes
+        summary_lines.append("\nFootnotes:")
+        for name, doc in footnotes.items():
+            summary_lines.extend([f"[{name}]", f"{doc}", ""])
+
+        return "\n".join(summary_lines)


### PR DESCRIPTION
- Introduced `SemantivaObject` as a superclass of `ContextProcessor` for unified semantic metadata handling
- Made context processor classmethods for key context operations (`get_required_keys`, `get_created_keys`, etc.)
- Replaced ContextNode with dynamically generated ContextProcessorNode via NodeFactory
  - Improves flexibility and encapsulation of context processor behavior
  - Adds structured metadata generation through _define_metadata method
- Injected auto-generated docstrings in context_renamer_factory and context_deleter_factory
- Refactored data_slicer_factory to append wrapped processor docstrings to dynamically generated slicer classes
- Updated Pipeline to support extended introspection and semantic summaries of each node
  - Introduced `extended_inspection` and `_print_nodes_semantic_ids` for verbose, structured reporting
