### PR TITLE
Made small improvement in fall_back version of toml pdm versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ cicheck = "bash ./ci_pipeline.sh"  # Define the shell script as a PDM script
 
 [tool.pdm.version]
 source = "scm"
-fallback_version = "0.0.0"
+fallback_version = "0.1.0-dev0+gUNKNOWN"


### PR DESCRIPTION
* Made really small improvement in the fallback version of pdm versioning. 

After the suggestion of addind the last git commit in the fall back version, I did some research on how this works, and in fact the pdm adds the commit hash by default in they builds. e. g. for imaging: 

`semantiva_imaging-0.0.2.dev2+gd955fc6.tar.gz`

The fall back version occurs when pdm does not have access to git medatada (when does not find the `.git` hidden folder). So, this is a really unusual situation. I think the static call back with the `unknown` keyword representing that we dont know the exact commit hash is enough. 

If a pdm build is done without git metadata, we get:

`semantiva_imaging-0.1.0.dev0+gunknown-py3-none-any.whl`

The same PR will be made for  the imaging repo

