### PR TITLE
Modified `node_factory` making node classes static

### DIFF
--- a/semantiva/data_processors/data_io_wrapper_factory.py
+++ b/semantiva/data_processors/data_io_wrapper_factory.py
@@ -19,7 +19,7 @@ class DataIOWrapperFactory:
         data_io_class: (
             Type[DataSource] | Type[PayloadSource] | Type[DataSink] | Type[PayloadSink]
         ),
-    ):
+    ) -> Type[DataOperation]:
         """
         Dynamically creates a subclass of DataOperation that wraps a data IO class.
 
@@ -60,7 +60,6 @@ class DataIOWrapperFactory:
                         List[str]: A list of parameter names (excluding `self` and `data`).
                     """
                     my_class = data_io_class()
-                    print(data_io_class.__dict__)
                     signature = inspect.signature(data_io_class._get_data)
                     return [
                         param.name
@@ -93,7 +92,6 @@ class DataIOWrapperFactory:
                         List[str]: A list of parameter names (excluding `self` and `data`).
                     """
                     my_class = data_io_class()
-                    print(data_io_class.__dict__)
                     signature = inspect.signature(data_io_class._get_payload)
                     return [
                         param.name

--- a/semantiva/data_processors/data_processors.py
+++ b/semantiva/data_processors/data_processors.py
@@ -315,7 +315,13 @@ class DataProbe(BaseDataProcessor):
 
     @classmethod
     def get_created_keys(cls) -> List[str]:
-        """ """
+        """
+        Retrieve a list of context keys created by the data probe.
+
+        Returns:
+            List[str]: A list of context keys created or modified by the data probe.
+        """
+
         return []
 
     @classmethod

--- a/semantiva/payload_operations/__init__.py
+++ b/semantiva/payload_operations/__init__.py
@@ -1,7 +1,18 @@
 from .nodes.node_factory import node_factory
 from .payload_processors import PayloadProcessor
 from .pipeline import Pipeline
-from .nodes.nodes import DataNode, ProbeNode, PipelineNode
+from .nodes.nodes import (
+    DataNode,
+    ProbeNode,
+    PipelineNode,
+    DataSinkNode,
+    DataSourceNode,
+    PayloadSinkNode,
+    PayloadSourceNode,
+    ContextProcessorNode,
+    ProbeContextInjectorNode,
+    ProbeResultCollectorNode,
+)
 
 __all__ = [
     "node_factory",
@@ -9,6 +20,12 @@ __all__ = [
     "Pipeline",
     "DataNode",
     "ProbeNode",
-    "StopWatch",
     "PipelineNode",
+    "DataSinkNode",
+    "DataSourceNode",
+    "PayloadSinkNode",
+    "PayloadSourceNode",
+    "ContextProcessorNode",
+    "ProbeContextInjectorNode",
+    "ProbeResultCollectorNode",
 ]

--- a/semantiva/payload_operations/nodes/node_factory.py
+++ b/semantiva/payload_operations/nodes/node_factory.py
@@ -1,21 +1,23 @@
-from typing import List, Any, Dict, Optional, Tuple, Type
+from types import new_class
+from typing import Any, Dict, Optional, Type
 from semantiva.data_processors.data_io_wrapper_factory import DataIOWrapperFactory
 from semantiva.data_io import DataSource, PayloadSource, DataSink, PayloadSink
-from semantiva.data_processors import DataOperation, DataProbe
-from semantiva.data_types import BaseDataType, NoDataType
+from semantiva.data_processors import DataOperation, DataProbe, BaseDataProcessor
 from semantiva.component_loader import ComponentLoader
 from semantiva.logger import Logger
 from semantiva.context_processors import (
-    ContextType,
-    ContextCollectionType,
-    ContextObserver,
     ContextProcessor,
 )
-from semantiva.logger import Logger
 from .nodes import (
-    DataNode,
-    ProbeNode,
     PipelineNode,
+    PayloadSourceNode,
+    PayloadSinkNode,
+    DataSinkNode,
+    DataSourceNode,
+    OperationNode,
+    ProbeContextInjectorNode,
+    ProbeResultCollectorNode,
+    ContextProcessorNode,
 )
 
 
@@ -23,6 +25,24 @@ class NodeFactory:
     """
     Factory class to create nodes based on the provided configuration.
     """
+
+    @staticmethod
+    def _create_class(
+        name: str,
+        base_cls: Type,
+        **class_attrs: Any,
+    ) -> Type:
+        """
+        Dynamically create a subclass of `base_cls` whose namespace is
+        pre‑populated with `class_attrs`.
+        """
+        return new_class(
+            name,
+            (base_cls,),
+            {},
+            # callback that fills the namespace
+            lambda ns: ns.update(class_attrs),
+        )
 
     @staticmethod
     def create_io_node(
@@ -57,892 +77,353 @@ class NodeFactory:
         if processor is None or not isinstance(processor, type):
             raise ValueError("processor must be a class type or a string, not None.")
 
-        elif issubclass(processor, DataSource):
-            return NodeFactory.create_data_source_node(logger, processor, parameters)
-        elif issubclass(processor, PayloadSource):
-            return NodeFactory.create_payload_source_node(logger, processor, parameters)
-        elif issubclass(processor, DataSink):
+        if issubclass(processor, DataSource):
+            return NodeFactory.create_data_source_node(processor, parameters, logger)
+        if issubclass(processor, PayloadSource):
+            return NodeFactory.create_payload_source_node(processor, parameters, logger)
+        if issubclass(processor, DataSink):
             return NodeFactory.create_data_sink_node(processor, parameters)
-        elif issubclass(processor, PayloadSink):
+        if issubclass(processor, PayloadSink):
             return NodeFactory.create_payload_sink_node(processor, parameters)
-        else:
-            raise ValueError(
-                "Unsupported processor. Processor must be of type DataOperation, DataProbe, DataSource, PayloadSource, DataSink, or PayloadSink."
-            )
 
-    @staticmethod
-    def create_payload_source_node(logger, processor_class, parameters):
-
-        class PayloadSourceNode(DataNode):
-            """
-            A node that loads data from a payload source.
-
-            This node wraps a PayloadSource to load data and inject it into the pipeline.
-
-            Attributes:
-                payload_source (PayloadSource): The payload source instance used to load data.
-            """
-
-            processor = DataIOWrapperFactory.create_data_operation(processor_class)
-
-            def __init__(
-                self,
-                processor_parameters: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize a PayloadSourceNode with the specified payload source.
-
-                Args:
-                    processor (Type[PayloadSource]): The payload source class for this node.
-                    processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-                """
-                super().__init__(
-                    self.processor,
-                    processor_parameters,
-                    logger,
-                )
-
-            @classmethod
-            def output_data_type(cls):
-                """
-                Retrieve the node's output data type.
-                """
-                return cls.processor.output_data_type()
-
-            @classmethod
-            def get_created_keys(cls):
-                """
-                Retrieve a list of context keys that will be created by the processor.
-
-                Returns:
-                    List[str]: An empty list indicating that no keys will be created.
-                """
-                cls.processor.get_created_keys()
-
-            def _process_single_item_with_context(
-                self, data: BaseDataType, context: ContextType
-            ) -> Tuple[BaseDataType, ContextType]:
-                """
-                Process a single data item with its corresponding single context.
-
-                Args:
-                    data (BaseDataType): A single data instance.
-                    context (ContextType): The corresponding single context.
-
-                Returns:
-                    Tuple[BaseDataType, ContextType]: The processed data and updated context.
-                """
-
-                # Save the current context to be used by the processor
-                self.observer_context = context
-                parameters = self._get_processor_parameters(self.observer_context)
-                loaded_data, loaded_context = self.processor.process(data, **parameters)
-
-                # Merge context and loaded_context
-                for key, value in loaded_context.items():
-                    if key in context.keys():
-                        raise KeyError(f"Key '{key}' already exists in the context.")
-                    context.set_value(key, value)
-                return loaded_data, context
-
-            @classmethod
-            def _define_metadata(cls):
-
-                # Define the metadata for the PayloadSourceNode
-                component_metadata = {
-                    "component_type": "PayloadSourceNode",
-                    "payload_source": cls.data_io_class.__name__,
-                    "input_parameters": cls.data_io_class.get_input_parameters(),
-                    "input_data_type": "NoDataType",
-                    "output_data_type": cls.output_data_type(),
-                    "injected_context_keys": cls.get_created_keys() or "None",
-                }
-                return component_metadata
-
-        return PayloadSourceNode(
-            data_io_class=processor,
-            processor_parameters=parameters,
-            logger=logger,
+        raise ValueError(
+            "Unsupported processor. Processor must be of type DataOperation, DataProbe, DataSource, PayloadSource, DataSink, or PayloadSink."
         )
 
     @staticmethod
-    def create_payload_sink_node(processor, parameters):
+    def create_payload_source_node(
+        data_io_class: Type[PayloadSource],
+        parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ) -> PayloadSourceNode:
+        """Factory function to create an extended PayloadSourceNode.
+        This function dynamically creates a subclass of PayloadSourceNode
+        with a specific payload source class and its associated metadata.
 
-        class PayloadSinkNode(DataNode):
-            """
-            A node that saves data using a payload sink.
+        Args:
+            data_io_class (Type[PayloadSource]): The class of the payload source to be used.
+            parameters (Optional[Dict]): Configuration parameters for the payload source. Defaults to None.
+            logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
+        Returns:
+            PayloadSourceNode: An instance of a dynamically created subclass of PayloadSourceNode.
+        """
 
-            This node wraps a PayloadSink to save data at the end of a pipeline.
+        processor = DataIOWrapperFactory.create_data_operation(data_io_class)
 
-            Attributes:
-                payload_sink (PayloadSink): The payload sink instance used to save data.
-            """
+        def _define_metadata(cls):  # IMPROVE
+            return {
+                "component_type": "PayloadSourceNode",
+                "payload_source": data_io_class.__name__,
+                "payload_source_doc": data_io_class.__doc__,
+                "input_data_type": "NoDataType",
+                "output_data_type": cls.output_data_type().__name__,
+                "injected_context_keys": cls.get_created_keys() or "None",
+                "parameters_schema": data_io_class.get_input_parameters(),
+            }
 
-            def __init__(
-                self,
-                data_io_class: Type[PayloadSink],
-                processor_parameters: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize a PayloadSinkNode with the specified payload sink.
-
-                Args:
-                    processor (Type[PayloadSink]): The payload sink class for this node.
-                    processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-                """
-                super().__init__(
-                    DataIOWrapperFactory.create_data_operation(data_io_class),
-                    processor_parameters,
-                    logger,
-                )
-
-            @classmethod
-            def get_created_keys(cls):
-                """
-                Retrieve a list of context keys that will be created by the processor.
-
-                Returns:
-                    List[str]: An empty list indicating that no keys will be created.
-                """
-                return []
-
-            def output_data_type(self):
-                """
-                Retrieve this node's output data type. Payload sink nodes act as data passthough.
-                """
-                return self.input_data_type()
-
-            def _process_single_item_with_context(
-                self, data: BaseDataType, context: ContextType
-            ) -> Tuple[BaseDataType, ContextType]:
-                """
-                Process a single data item with its corresponding single context.
-
-                Args:
-                    data (BaseDataType): A single data instance.
-                    context (ContextType): The corresponding single context.
-
-                Returns:
-                    Tuple[BaseDataType, ContextType]: The processed data and updated context.
-                """
-
-                # Save the current context to be used by the processor
-                self.observer_context = context
-                parameters = self._get_processor_parameters(self.observer_context)
-                output_data = self.processor.process(data, **parameters)
-
-                return output_data, self.observer_context
-
-            @classmethod
-            def _define_metadata(cls):
-
-                # Define the metadata for the PayloadSinkNode
-                component_metadata = {
-                    "component_type": "PayloadSinkNode",
-                    "payload_source": cls.data_io_class.__name__,
-                    "input_parameters": cls.data_io_class.get_input_parameters(),
-                    "input_data_type": cls.input_data_type(),
-                    "output_data_type": cls.input_data_type(),  # DataSinkNodes act as data passthrough
-                    "injected_context_keys": cls.get_created_keys() or "None",
-                }
-                return component_metadata
-
-        return PayloadSinkNode(
-            data_io_class=processor,
-            processor_parameters=parameters,
+        node_class = NodeFactory._create_class(
+            name=f"PayloadSourceNodeWrapping{data_io_class.__name__}",
+            base_cls=PayloadSourceNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=data_io_class,
+        )
+        return node_class(
+            processor=processor, processor_parameters=parameters, logger=logger
         )
 
     @staticmethod
-    def create_data_sink_node(processor_class, parameters):
+    def create_payload_sink_node(
+        data_io_class: Type[PayloadSink], parameters: Optional[Dict] = None
+    ) -> PayloadSinkNode:
+        """Factory function to create an extended PayloadSinkNode.
+        This function dynamically creates a subclass of PayloadSinkNode
+        with a specific payload sink class and its associated metadata.
+        Args:
+            data_io_class (Type[PayloadSink]): The class of the payload sink to be used.
+            parameters (Optional[Dict]): Configuration parameters for the payload sink. Defaults to None.
+        Returns:
+            PayloadSinkNode: An instance of a dynamically created subclass of PayloadSinkNode.
+        """
 
-        class DataSinkNode(DataNode):
-            """
-            A node that saves data using a data sink.
+        processor = DataIOWrapperFactory.create_data_operation(data_io_class)
 
-            This node wraps a DataSink to save data at the end of a pipeline.
+        def _define_metadata(cls):  # IMPROVE
 
-            Attributes:
-                data_sink (DataSink): The data sink instance used to save data.
-            """
+            # Define the metadata for the PayloadSinkNode
+            component_metadata = {
+                "component_type": "PayloadSinkNode",
+                "payload_source": cls.data_io_class.__name__,
+                "input_parameters": cls.data_io_class.get_input_parameters(),
+                "input_data_type": cls.input_data_type(),
+                "output_data_type": cls.input_data_type(),  # DataSinkNodes act as data passthrough
+                "injected_context_keys": cls.get_created_keys() or "None",
+            }
+            return component_metadata
 
-            processor = processor_class
+        node_class = NodeFactory._create_class(
+            name=f"PayloadSinkNodeWrapping{data_io_class.__name__}",
+            base_cls=PayloadSinkNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=data_io_class,
+        )
+        return node_class(processor=processor, processor_parameters=parameters)
 
-            def __init__(
-                self,
-                processor_parameters: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize a DataSinkNode with the specified data sink.
+    @staticmethod
+    def create_data_sink_node(
+        data_io_class: Type[DataSink], parameters: Optional[Dict] = None
+    ) -> DataSinkNode:
+        """Factory function to create an extended DataSinkNode.
+        This function dynamically creates a subclass of DataSinkNode
+        with a specific data sink class.
+        Args:
+            data_io_class (Type[DataSink]): The class of the data sink to be used.
+            parameters (Optional[Dict]): Configuration parameters for the payload sink. Defaults to None.
+        Returns:
+            DataSinkNode: An instance of a dynamically created subclass of DataSinkNode.
+        """
 
-                Args:
-                    processor (Type[DataSink]): The data sink class for this node.
-                    processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-                """
-                super().__init__(
-                    DataIOWrapperFactory.create_data_operation(self.processor),
-                    processor_parameters,
-                    logger,
+        processor = DataIOWrapperFactory.create_data_operation(data_io_class)
+
+        def _define_metadata(cls):
+            excluded_parameters = ["self", "data"]
+            annotated_parameter_list = [
+                f"{param_name}: {param_type}"
+                for param_name, param_type in cls._retrieve_parameter_signatures(
+                    cls.processor._send_data, excluded_parameters
                 )
+            ]
 
-            @classmethod
-            def input_data_type(cls):
-                """
-                Retrieve the data type that will be produced by the processor.
+            # Define the metadata for the DataSinkNode
+            component_metadata = {
+                "component_type": "DataSinkNode",
+                "processor": cls.processor.__name__,
+                "processor_docstring": cls.processor.get_metadata().get("docstring"),
+                "input_parameters": annotated_parameter_list or "None",
+                "input_data_type": cls.input_data_type().__name__,
+                "output_data_type": cls.input_data_type().__name__,  # DataSinkNodes act as data passthrough
+                "injected_context_keys": cls.get_created_keys() or "None",
+            }
+            return component_metadata
 
-                Returns:
-                    Type: The data type that will be produced by the processor.
-                """
-                return cls.processor.input_data_type()
+        node_class = NodeFactory._create_class(
+            name=f"DataSinkNodeWrapping{data_io_class.__name__}",
+            base_cls=DataSinkNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=data_io_class,
+        )
 
-            @classmethod
-            def output_data_type(cls):
-                """
-                Retrieve the data type that will be produced by the processor.
+        return node_class(processor=processor, processor_parameters=parameters)
 
-                Returns:
-                    Type: The data type that will be produced by the processor.
-                """
-                return cls.input_data_type()
+    @staticmethod
+    def create_data_source_node(
+        data_io_class: Type[DataSource],
+        parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ) -> DataSourceNode:
+        """Factory function to create an extended DataSourceNode.
+        This function dynamically creates a subclass of DataSourceNode
+        with a specific data source class.
+        Args:
+            data_io_class (Type[DataSource]): The class of the data source to be used.
+            parameters (Optional[Dict]): Configuration parameters for the data source. Defaults to None.
+            logger (Optional[Logger]): A Logger instance. Defaults to None
+        Returns:
+            DataSinkNode: An instance of a dynamically created subclass of DataSourceNode.
+        """
 
-            @classmethod
-            def get_created_keys(cls):
-                """
-                Retrieve a list of context keys that will be created by the processor.
+        processor = DataIOWrapperFactory.create_data_operation(data_io_class)
 
-                Returns:
-                    List[str]: An empty list indicating that no keys will be created.
-                """
-                return []
+        def _define_metadata(cls) -> Dict:
 
-            def _process_single_item_with_context(
-                self, data: BaseDataType, context: ContextType
-            ) -> Tuple[BaseDataType, ContextType]:
-                """
-                Process a single data item with its corresponding single context.
+            # Define the metadata for the DataSourceNode
+            component_metadata = {
+                "component_type": "DataSourceNode",
+                "processor": cls.processor.__name__,
+                "processor_docstring": cls.processor.get_metadata().get("docstring"),
+                "input_data_type": "NoDataType",
+                "output_data_type": cls.output_data_type().__name__,
+                "injected_context_keys": cls.get_created_keys() or "None",
+            }
+            return component_metadata
 
-                Args:
-                    data (BaseDataType): A single data instance.
-                    context (ContextType): The corresponding single context.
+        node_class = NodeFactory._create_class(
+            name=f"DataSourceNodeWrapping{data_io_class.__name__}",
+            base_cls=DataSourceNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=data_io_class,
+        )
 
-                Returns:
-                    Tuple[BaseDataType, ContextType]: The processed data and updated context.
-                """
-
-                # Save the current context to be used by the processor
-                self.observer_context = context
-                parameters = self._get_processor_parameters(self.observer_context)
-                output_data = self.processor.process(data, **parameters)
-
-                return output_data, self.observer_context
-
-            @classmethod
-            def _define_metadata(cls):
-                excluded_parameters = ["self", "data"]
-                annotated_parameter_list = [
-                    f"{param_name}: {param_type}"
-                    for param_name, param_type in cls._retrieve_parameter_signatures(
-                        cls.processor._send_data, excluded_parameters
-                    )
-                ]
-
-                # Define the metadata for the DataSinkNode
-                component_metadata = {
-                    "component_type": "DataSinkNode",
-                    "processor": cls.processor.__name__,
-                    "processor_docstring": cls.processor.get_metadata().get(
-                        "docstring"
-                    ),
-                    "input_parameters": annotated_parameter_list or "None",
-                    "input_data_type": cls.input_data_type().__name__,
-                    "output_data_type": cls.input_data_type().__name__,  # DataSinkNodes act as data passthrough
-                    "injected_context_keys": cls.get_created_keys() or "None",
-                }
-                return component_metadata
-
-        return DataSinkNode(
-            processor_parameters=parameters,
+        return node_class(
+            processor=processor, processor_parameters=parameters, logger=logger
         )
 
     @staticmethod
-    def create_data_source_node(logger, processor_class, parameters):
-        class DataSourceNode(DataNode):
-            """
-            A node that loads data from a data source.
+    def create_operation_node(
+        processor_class: Type[BaseDataProcessor],
+        parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ) -> OperationNode:
+        """Factory function to create an extended OperationNode.
+        This function dynamically creates a subclass of OperationNode
+        with a specific data source class.
+        Args:
+            processor_class (Type[BaseDataProcessor]): The class of the data operation to be used.
+            parameters (Optional[Dict]): Configuration parameters for the data source. Defaults to None.
+            logger (Optional[Logger]): A Logger instance. Defaults to None
+        Returns:
+            DataOperationNode: An instance of a dynamically created subclass of DataSourceNode.
+        """
 
-            This node wraps a DataSource to load data and inject it into the pipeline.
+        def _define_metadata(cls) -> Dict:
+            # Define the metadata for the DataOperationNode
+            component_metadata = {
+                "component_type": "DataOperationNode",
+                "processor": cls.processor.__name__,
+                "processor_docstring": cls.processor.get_metadata().get("docstring"),
+                "input_parameters": cls.processor.get_processing_parameter_names(),
+                "input_data_type": cls.input_data_type().__name__,
+                "output_data_type": cls.output_data_type().__name__,
+                "injected_context_keys": cls.get_created_keys() or "None",
+            }
 
-            Attributes:
-                data_source (DataSource): The data source instance used to load data.
-            """
+            return component_metadata
 
-            processor = processor_class
-
-            def __init__(
-                self,
-                processor_parameters: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize a DataSourceNode with the specified data source.
-
-                Args:
-                    processor (Type[DataSource]): The data source class for this node.
-                    processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-                """
-                super().__init__(
-                    DataIOWrapperFactory.create_data_operation(self.processor),
-                    processor_parameters,
-                    logger,
-                )
-
-            @classmethod
-            def input_data_type(cls):
-                """
-                Retrieve the data type that will be consumed by the processor.
-
-                Returns:
-                    Type: The data type that will be consumed by the processor.
-                """
-                return NoDataType
-
-            @classmethod
-            def output_data_type(cls):
-                """
-                Retrieve the data type that will be produced by the processor.
-
-                Returns:
-                    Type: The data type that will be produced by the processor.
-                """
-                return cls.processor.output_data_type()
-
-            @classmethod
-            def get_created_keys(cls):
-                """
-                Retrieve a list of context keys that will be created by the processor.
-
-                Returns:
-                    List[str]: A list of context keys that the processor will add or create
-                            as a result of execution.
-                """
-                return []
-
-            def _process_single_item_with_context(
-                self, data: BaseDataType, context: ContextType
-            ) -> Tuple[BaseDataType, ContextType]:
-                """
-                Process a single data item with its corresponding single context.
-
-                Args:
-                    data (BaseDataType): A single data instance.
-                    context (ContextType): The corresponding single context.
-
-                Returns:
-                    Tuple[BaseDataType, ContextType]: The processed data and updated context.
-                """
-
-                # Save the current context to be used by the processor
-                self.observer_context = context
-                parameters = self._get_processor_parameters(self.observer_context)
-                output_data = self.processor.process(data, **parameters)
-
-                return output_data, self.observer_context
-
-            @classmethod
-            def _define_metadata(cls):
-
-                # Define the metadata for the DataSourceNode
-                component_metadata = {
-                    "component_type": "DataSourceNode",
-                    "processor": cls.processor.__name__,
-                    "processor_docstring": cls.processor.get_metadata().get(
-                        "docstring"
-                    ),
-                    "input_data_type": "NoDataType",
-                    "output_data_type": cls.output_data_type().__name__,
-                    "injected_context_keys": cls.get_created_keys() or "None",
-                }
-                return component_metadata
-
-        return DataSourceNode(
-            processor_parameters=parameters,
-            logger=logger,
+        node_class = NodeFactory._create_class(
+            name=f"DataOperationNodeWrapping{processor_class.__name__}",
+            base_cls=OperationNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=processor_class,
         )
 
-    @staticmethod
-    def create_operation_node(logger, processor_class, parameters):
-
-        class OperationNode(DataNode):
-            """
-            Node that applies an data operation, potentially modifying it.
-            It interacts with `ContextObserver` to update the context.
-            """
-
-            processor = processor_class
-
-            def __init__(
-                self,
-                processor_parameters: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize an OperationNode with the specified data algorithm.
-
-                Args:
-                    processor (Type[DataOperation]): The data algorithm for this node.
-                    processor_parameters (Optional[Dict]): Initial configuration for processor parameters. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-                """
-                processor_parameters = (
-                    {} if processor_parameters is None else processor_parameters
-                )
-                super().__init__(self.processor, processor_parameters, logger)
-
-            @classmethod
-            def input_data_type(cls):
-                """
-                Retrieve input data type of the data processor.
-
-                """
-                return cls.processor.input_data_type()
-
-            @classmethod
-            def output_data_type(cls):
-                """
-                Retrieve the node's output data type. The request is delegated to the node's data processor.
-
-                Returns:
-                    Type: The node output data type.
-                """
-                return cls.processor.output_data_type()
-
-            @classmethod
-            def get_created_keys(cls):
-                """
-                Retrieve a list of context keys that will be created by the processor.
-
-                Returns:
-                    List[str]: A list of context keys that the processor will add or create
-                            as a result of execution.
-                """
-                return cls.processor.get_created_keys()
-
-            def _process_single_item_with_context(
-                self, data: BaseDataType, context: ContextType
-            ) -> Tuple[BaseDataType, ContextType]:
-                """
-                Process a single data item with its corresponding single context.
-
-                Args:
-                    data (BaseDataType): A single data instance.
-                    context (ContextType): The corresponding context.
-
-                Returns:
-                    Tuple[BaseDataType, ContextType]: The processed data and the updated context.
-                """
-
-                # Save the current context to be used by the processor
-                self.observer_context = context
-                parameters = self._get_processor_parameters(self.observer_context)
-                output_data = self.processor.process(data, **parameters)
-
-                return output_data, self.observer_context
-
-            @classmethod
-            def _define_metadata(cls):
-                # Define the metadata for the DataOperationNode
-                component_metadata = {
-                    "component_type": "DataOperationNode",
-                    "processor": cls.processor.__name__,
-                    "processor_docstring": cls.processor.get_metadata().get(
-                        "docstring"
-                    ),
-                    "input_parameters": cls.processor.get_processing_parameter_names(),
-                    "input_data_type": cls.input_data_type().__name__,
-                    "output_data_type": cls.output_data_type().__name__,
-                    "injected_context_keys": cls.get_created_keys() or "None",
-                }
-
-                return component_metadata
-
-        return OperationNode(
-            processor_parameters=parameters,
-            logger=logger,
+        return node_class(
+            processor=processor_class, processor_parameters=parameters, logger=logger
         )
 
     @staticmethod
     def create_probe_context_injector(
-        logger, processor_class, parameters, context_keyword_
-    ):
-        if not context_keyword_ or not isinstance(context_keyword_, str):
+        processor_class: Type[BaseDataProcessor],
+        context_keyword: str,
+        parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ) -> ProbeContextInjectorNode:
+        """Factory function to create an extended ProbeContextInjectorNode.
+        This function dynamically creates a subclass of ProbeContextInjectorNode
+        with a specific data processor class.
+        Args:
+            processor_class (Type[BaseDataProcessor]): The class of the data operation to be used.
+            context_keyword (str): The context key for the probe result.
+            parameters (Optional[Dict]): Configuration parameters. Defaults to None.
+            logger (Optional[Logger]): A Logger instance. Defaults to None
+        Returns:
+            ProbeContextInjectorNode: An instance of a dynamically created subclass of ProbeContextInjectorNode.
+        """
+
+        if not context_keyword or not isinstance(context_keyword, str):
             raise ValueError("context_keyword must be a non-empty string.")
 
-        class ProbeContextInjectorNode(ProbeNode):
-            """
-            A node that injects probe results into the execution context.
+        def _define_metadata(cls):
 
-            This node uses a data probe to extract information from the input data
-            and then injects the result into the context under a specified keyword.
+            # Define the metadata for the ProbeContextInjectorNode
+            component_metadata = {
+                "component_type": "ProbeContextInjectorNode",
+                "processor": cls.processor.__name__,
+                "processor_docstring": cls.processor.get_metadata().get("docstring"),
+                "input_data_type": cls.input_data_type().__name__,
+                "output_data_type": cls.input_data_type().__name__,  # Probe nodes have the same input and output data types
+                "injected_context_keys": cls.get_created_keys() or "None",
+            }
+            return component_metadata
 
-            Attributes:
-                context_keyword (str): The key under which the probe result is stored in the context.
-            """
+        node_class = NodeFactory._create_class(
+            name=f"ProbeContextInjectorNodeWrapping{processor_class.__name__}",
+            base_cls=ProbeContextInjectorNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=processor_class,
+            context_keyword=context_keyword,
+        )
+        return node_class(processor_class, context_keyword, parameters, logger)
 
-            processor = processor_class
-            context_keyword = context_keyword_
+    @staticmethod
+    def create_probe_result_collector(
+        processor_class: Type[BaseDataProcessor],
+        parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ) -> ProbeResultCollectorNode:
+        """Factory function to create an extended ProbeResultCollectorNode.
+        This function dynamically creates a subclass of ProbeResultCollectorNode
+        with a specific processor class.
+        Returns:
+            ProbeResultCollectorNode: An instance of a dynamically created subclass of ProbeNode.
+        """
 
-            def __init__(
-                self,
-                processor_parameters: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize a ProbeContextInjectorNode with the specified data processor and context keyword.
+        def _define_metadata(cls):
 
-                Args:
-                    processor (Type[BaseDataProcessor]): The data probe class for this node.
-                    context_keyword (str): The keyword used to inject the probe result into the context.
-                    processor_parameters (Optional[Dict]): Operation configuration parameters. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
+            # Define the metadata for the ProbeResultCollectorNode
+            component_metadata = {
+                "component_type": "ProbeResultCollectorNode",
+                "processor": cls.processor.__name__,
+                "processor_docstring": cls.processor.get_metadata().get("docstring"),
+                "input_data_type": cls.input_data_type().__name__,
+                "output_data_type": cls.input_data_type().__name__,  # Probe nodes have the same input and output data types
+                "injected_context_keys": cls.get_created_keys() or "None",
+            }
+            return component_metadata
 
-                Raises:
-                    ValueError: If `context_keyword` is not provided or is not a non-empty string.
-                """
-                super().__init__(self.processor, processor_parameters, logger)
-
-            @classmethod
-            def input_data_type(cls):
-                """
-                Retrieve the expected input data type for the data processor.
-
-                Returns:
-                    Type: The expected input data type for the data processor.
-                """
-                return cls.processor.input_data_type()
-
-            @classmethod
-            def output_data_type(cls):
-                """
-                Retrieve the output data type of the node, which is the same as the input data type for probe nodes.
-                """
-                return cls.processor.input_data_type()
-
-            @classmethod
-            def get_created_keys(cls):
-                """
-                Retrieve a list of context keys that will be created by the processor.
-
-                Returns:
-                    List[str]: A list of context keys that the processor will add or create
-                    as a result of execution.
-                """
-                return [cls.context_keyword]
-
-            def __str__(self) -> str:
-                """
-                Return a string representation of the ProbeContextInjectorNode.
-
-                Returns:
-                    str: A string summarizing the node's attributes and execution summary.
-                """
-                class_name = self.__class__.__name__
-                return (
-                    f"{class_name}(\n"
-                    f"     processor={self.processor},\n"
-                    f"     context_keyword={self.context_keyword},\n"
-                    f"     processor_config={self.processor_config},\n"
-                    f"     execution summary: {self.stop_watch}\n"
-                    f")"
-                )
-
-            def _process_single_item_with_context(
-                self, data: BaseDataType, context: ContextType
-            ) -> Tuple[BaseDataType, ContextType]:
-                """
-                Process a single data item and inject the probe result into the context.
-
-                Args:
-                    data (BaseDataType): A single data instance.
-                    context (ContextType): The context to be updated.
-
-                Returns:
-                    Tuple[BaseDataType, ContextType]: The unchanged data and the updated context with the probe result.
-                """
-
-                parameters = self._get_processor_parameters(context)
-                probe_result = self.processor.process(data, **parameters)
-                if isinstance(context, ContextCollectionType):
-                    for index, p_item in enumerate(probe_result):
-                        ContextObserver.update_context(
-                            context, self.context_keyword, p_item, index=index
-                        )
-                else:
-                    ContextObserver.update_context(
-                        context, self.context_keyword, probe_result
-                    )
-
-                return data, context
-
-            @classmethod
-            def _define_metadata(cls):
-
-                # Define the metadata for the ProbeContextInjectorNode
-                component_metadata = {
-                    "component_type": "ProbeContextInjectorNode",
-                    "processor": cls.processor.__name__,
-                    "processor_docstring": cls.processor.get_metadata().get(
-                        "docstring"
-                    ),
-                    "input_data_type": cls.input_data_type().__name__,
-                    "output_data_type": cls.input_data_type().__name__,  # Probe nodes have the same input and output data types
-                    "injected_context_keys": cls.get_created_keys() or "None",
-                }
-                return component_metadata
-
-        return ProbeContextInjectorNode(
+        node_class = NodeFactory._create_class(
+            name=f"ProbeResultCollectorNodeWrapping{processor_class.__name__}",
+            base_cls=ProbeResultCollectorNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=processor_class,
+        )
+        return node_class(
+            processor=processor_class,
             processor_parameters=parameters,
             logger=logger,
         )
 
     @staticmethod
-    def create_probe_result_collector(logger, processor_, parameters):
+    def create_context_processor_node(
+        processor_class: Type[ContextProcessor],
+        parameters: Optional[Dict] = None,
+        logger: Optional[Logger] = None,
+    ) -> ContextProcessorNode:
+        """Factory function to create an extended ContextProcessorNode.
+        This function dynamically creates a subclass of ContextProcessorNode
+        with a specific data processor class.
+        Args:
+            processor_class (Type[ContextProcessor]): The class of the context processor to be used.
+            parameters (Optional[Dict]): Configuration parameters for the context processor. Defaults to None.
+            logger (Optional[Logger]): A Logger instance. Defaults to None
+        Returns:
+            ContextProcessorNode: An instance of a dynamically created subclass of ContextProcessorNode.
+        """
 
-        class ProbeResultCollectorNode(ProbeNode):
-            """
-            A node for collecting probed data.
+        # Ensure parameters is a dictionary
+        parameters = parameters or {}
+        context_processor_instance = processor_class(logger, **parameters)
 
-            Attributes:
-                _probed_data (List[Any]): A list of probed data.
-            """
+        def _define_metadata(cls):
 
-            processor = processor_
+            # Define the metadata for the ContextProcessorNode
+            component_metadata = {
+                "component_type": "ContextProcessorNode",
+                "ContextProcessor": processor_class.__name__,
+                "processor_docstring": processor_class.get_metadata().get("docstring"),
+                "get_required_context_keys": cls.get_required_keys() or "None",
+                "get_suppressed_context_keys": cls.get_suppressed_keys() or "None",
+                "get_created_context_keys": cls.get_created_keys() or "None",
+            }
+            return component_metadata
 
-            def __init__(
-                self,
-                processor_parameters: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize a ProbeResultCollectorNode with the specified data probe.
-
-                Args:
-                    processor (Type[DataProbe]): The data probe class for this node.
-                    processor_parameters (Optional[Dict]): Configuration parameters for the processor. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-                """
-                super().__init__(self.processor, processor_parameters, logger)
-                self._probed_data: List[Any] = []
-
-            @classmethod
-            def input_data_type(cls):
-                """
-                Retrieve the expected input data type for the data processor.
-
-                Returns:
-                    Type: The expected input data type for the data processor.
-                """
-                return cls.processor.input_data_type()
-
-            @classmethod
-            def output_data_type(cls):
-                """
-                Retrieve the output data type of the node, which is the same as the input data type for probe nodes.
-                """
-                return cls.processor.input_data_type()
-
-            def collect(self, data: Any) -> None:
-                """
-                Collect data from the probe.
-
-                Args:
-                    data (Any): The data to collect.
-                """
-                self._probed_data.append(data)
-
-            def get_collected_data(self) -> List[Any]:
-                """
-                Retrieve all collected probe data.
-
-                Returns:
-                    List[Any]: The list of collected data.
-                """
-                return self._probed_data
-
-            def clear_collected_data(self) -> None:
-                """
-                Clear all collected data, useful for reuse in iterative processes.
-                """
-                self._probed_data.clear()
-
-            @classmethod
-            def get_created_keys(cls):
-                """
-                Retrieve the list of created keys.
-                Returns:
-                    list: An empty list indicating no keys have been created.
-                """
-
-                return []
-
-            def _process_single_item_with_context(
-                self, data: BaseDataType, context: ContextType
-            ) -> Tuple[BaseDataType, ContextType]:
-                """
-                Execute the probe on a single data item, collecting the result.
-
-                Args:
-                    data (BaseDataType): A single data instance.
-                    context (ContextType): The context, unchanged by this node.
-
-                Returns:
-                    Tuple[BaseDataType, ContextType]: The original data and unchanged context.
-                """
-                parameters = self._get_processor_parameters(context)
-                probe_result = self.processor.process(data, **parameters)
-                self.collect(probe_result)
-                return data, context
-
-            @classmethod
-            def _define_metadata(cls):
-
-                # Define the metadata for the ProbeResultCollectorNode
-                component_metadata = {
-                    "component_type": "ProbeResultCollectorNode",
-                    "processor": cls.processor.__name__,
-                    "processor_docstring": cls.processor.get_metadata().get(
-                        "docstring"
-                    ),
-                    "input_data_type": cls.input_data_type().__name__,
-                    "output_data_type": cls.input_data_type().__name__,  # Probe nodes have the same input and output data types
-                    "injected_context_keys": cls.get_created_keys() or "None",
-                }
-                return component_metadata
-
-        return ProbeResultCollectorNode(
-            processor_parameters=parameters,
-            logger=logger,
+        node_class = NodeFactory._create_class(
+            name=f"ContextProcessorNodeWrapping{processor_class.__name__}",
+            base_cls=ContextProcessorNode,
+            _define_metadata=classmethod(_define_metadata),
+            processor=context_processor_instance,
         )
-
-    @staticmethod
-    def create_context_processor_node(logger, processor_, parameters):
-
-        context_processor_instance = processor_(logger, **parameters)
-
-        class ContextProcessorNode(PipelineNode):
-            """
-            A node that wrapps a context processor.
-            """
-
-            processor = processor_
-
-            def __init__(
-                self,
-                processor_config: Optional[Dict] = None,
-                logger: Optional[Logger] = None,
-            ):
-                """
-                Initialize a Node with the specified context processor, and parameters.
-
-                Args:
-                    processor (Type[ContextProcessor]): The class of the context processor associated with this node.
-                    processor_config (Optional[Dict]): Operation parameters. Defaults to None.
-                    logger (Optional[Logger]): A logger instance for logging messages. Defaults to None.
-                """
-                super().__init__(logger)
-                self.logger.debug(
-                    f"Initializing {self.__class__.__name__} ({processor_.__name__})"
-                )
-                processor_config = processor_config or {}
-                self.processor = processor_(logger, **processor_config)
-                self.processor_config = processor_config
-
-            def __str__(self) -> str:
-                """
-                Return a string representation of the node.
-
-                Returns:
-                    str: A string summarizing the node's attributes and execution summary.
-                """
-                class_name = self.__class__.__name__
-                return (
-                    f"{class_name}(\n"
-                    f"     processor={self.processor},\n"
-                    f"     processor_config={self.processor_config},\n"
-                    f"     Execution summary: {self.stop_watch}\n"
-                    f")"
-                )
-
-            @classmethod
-            def get_created_keys(cls) -> List[str]:
-                """
-                Retrieve a list of context keys that will be created by the processor.
-
-                Returns:
-                    List[str]: A list of context keys that the processor will add or modify during its execution.
-                """
-
-                return context_processor_instance.get_created_keys()
-
-            @classmethod
-            def get_required_keys(cls) -> List[str]:
-                """
-                Retrieve a list of context keys required by the processor.
-
-                Returns:
-                    List[str]: A list of context keys.
-                """
-                return context_processor_instance.get_required_keys()
-
-            @classmethod
-            def get_suppressed_keys(cls) -> List[str]:
-                """
-                Retrieve a list of context keys that will be removed by the processor.
-
-                Returns:
-                    List[str]: A list of context keys that the processor will remove during its execution.
-                """
-                return context_processor_instance.get_suppressed_keys()
-
-            def _process(
-                self, data: BaseDataType, context: ContextType
-            ) -> tuple[BaseDataType, ContextType]:
-                """
-                Processes the given data and context.
-
-                Args:
-                    data (BaseDataType): The data to be processed.
-                    context (ContextType): The context in which the data is processed.
-
-                Returns:
-                    tuple[BaseDataType, ContextType]: A tuple containing the processed data and context.
-                """
-
-                updated_context = self.processor.operate_context(context)
-
-                return data, updated_context
-
-            @classmethod
-            def _define_metadata(cls):
-
-                # Define the metadata for the ContextProcessorNode
-                component_metadata = {
-                    "component_type": "ContextProcessorNode",
-                    "ContextProcessor": processor_.__name__,
-                    "processor_docstring": processor_.get_metadata().get("docstring"),
-                    "get_required_context_keys": cls.get_required_keys() or "None",
-                    "get_suppressed_context_keys": cls.get_suppressed_keys() or "None",
-                    "get_created_context_keys": cls.get_created_keys() or "None",
-                }
-                return component_metadata
-
-        return ContextProcessorNode(
-            parameters,
+        return node_class(
+            processor=processor_class,
+            processor_config=parameters,
             logger=logger,
         )
 
@@ -988,24 +469,24 @@ def node_factory(
         raise ValueError("processor must be a class type or a string, not None.")
 
     if issubclass(processor, ContextProcessor):
-        return NodeFactory.create_context_processor_node(logger, processor, parameters)
+        return NodeFactory.create_context_processor_node(processor, parameters, logger)
 
-    elif issubclass(processor, DataOperation):
+    if issubclass(processor, DataOperation):
         if context_keyword is not None:
             raise ValueError(
                 "context_keyword must not be defined for DataOperation nodes."
             )
-        return NodeFactory.create_operation_node(logger, processor, parameters)
-    elif issubclass(processor, DataProbe):
+        return NodeFactory.create_operation_node(processor, parameters, logger)
+    if issubclass(processor, DataProbe):
         if context_keyword is not None:
             return NodeFactory.create_probe_context_injector(
-                logger, processor, parameters, context_keyword
+                processor, context_keyword, parameters, logger
             )
         else:
             return NodeFactory.create_probe_result_collector(
-                logger, processor, parameters
+                processor, parameters, logger
             )
-    elif issubclass(processor, (DataSource, PayloadSource, DataSink, PayloadSink)):
+    if issubclass(processor, (DataSource, PayloadSource, DataSink, PayloadSink)):
         return NodeFactory.create_io_node(node_definition, logger)
     else:
         raise ValueError(

--- a/semantiva/payload_operations/nodes/node_factory.py
+++ b/semantiva/payload_operations/nodes/node_factory.py
@@ -122,7 +122,7 @@ class NodeFactory:
             }
 
         node_class = NodeFactory._create_class(
-            name=f"PayloadSourceNodeWrapping{data_io_class.__name__}",
+            name="PayloadSourceNode",
             base_cls=PayloadSourceNode,
             _define_metadata=classmethod(_define_metadata),
             processor=data_io_class,
@@ -161,7 +161,7 @@ class NodeFactory:
             return component_metadata
 
         node_class = NodeFactory._create_class(
-            name=f"PayloadSinkNodeWrapping{data_io_class.__name__}",
+            name=f"{data_io_class.__name__}PayloadSinkNode",
             base_cls=PayloadSinkNode,
             _define_metadata=classmethod(_define_metadata),
             processor=data_io_class,
@@ -206,7 +206,7 @@ class NodeFactory:
             return component_metadata
 
         node_class = NodeFactory._create_class(
-            name=f"DataSinkNodeWrapping{data_io_class.__name__}",
+            name=f"{data_io_class.__name__}DataSinkNode",
             base_cls=DataSinkNode,
             _define_metadata=classmethod(_define_metadata),
             processor=data_io_class,
@@ -247,7 +247,7 @@ class NodeFactory:
             return component_metadata
 
         node_class = NodeFactory._create_class(
-            name=f"DataSourceNodeWrapping{data_io_class.__name__}",
+            name="DataSourceNode",
             base_cls=DataSourceNode,
             _define_metadata=classmethod(_define_metadata),
             processor=data_io_class,
@@ -289,7 +289,7 @@ class NodeFactory:
             return component_metadata
 
         node_class = NodeFactory._create_class(
-            name=f"DataOperationNodeWrapping{processor_class.__name__}",
+            name=f"{processor_class.__name__}DataOperationNode",
             base_cls=OperationNode,
             _define_metadata=classmethod(_define_metadata),
             processor=processor_class,
@@ -335,7 +335,7 @@ class NodeFactory:
             return component_metadata
 
         node_class = NodeFactory._create_class(
-            name=f"ProbeContextInjectorNodeWrapping{processor_class.__name__}",
+            name=f"{processor_class.__name__}ProbeContextInjectorNode",
             base_cls=ProbeContextInjectorNode,
             _define_metadata=classmethod(_define_metadata),
             processor=processor_class,
@@ -370,7 +370,7 @@ class NodeFactory:
             return component_metadata
 
         node_class = NodeFactory._create_class(
-            name=f"ProbeResultCollectorNodeWrapping{processor_class.__name__}",
+            name=f"{processor_class.__name__}ProbeResultCollectorNode",
             base_cls=ProbeResultCollectorNode,
             _define_metadata=classmethod(_define_metadata),
             processor=processor_class,
@@ -416,7 +416,7 @@ class NodeFactory:
             return component_metadata
 
         node_class = NodeFactory._create_class(
-            name=f"ContextProcessorNodeWrapping{processor_class.__name__}",
+            name=f"{processor_class.__name__}ContextProcessorNode",
             base_cls=ContextProcessorNode,
             _define_metadata=classmethod(_define_metadata),
             processor=context_processor_instance,

--- a/semantiva/payload_operations/pipeline.py
+++ b/semantiva/payload_operations/pipeline.py
@@ -11,7 +11,8 @@ from .payload_processors import PayloadProcessor
 from .nodes.node_factory import node_factory
 from .nodes.nodes import (
     PipelineNode,
-    DataNode,
+    ContextProcessorNode,
+    ProbeResultCollectorNode,
 )
 
 
@@ -159,7 +160,7 @@ class Pipeline(PayloadProcessor):
         # Iterate over all nodes in the pipeline
         for i, node in enumerate(self.nodes):
 
-            if node.get_metadata().get("component_type") == "ProbeResultCollectorNode":
+            if isinstance(node, ProbeResultCollectorNode):
                 # Add the collected data from the node to the results dictionary
                 assert hasattr(node, "get_collected_data")
                 probe_results[f"Node {i + 1}/{type(node.processor).__name__}"] = (
@@ -185,7 +186,7 @@ class Pipeline(PayloadProcessor):
             nodes.append(node)
 
             # Skip type consistency check for `ContextProcessorNode`
-            if node.get_metadata().get("component_type") == "ContextProcessorNode":
+            if isinstance(node, ContextProcessorNode):
                 continue
 
             # Perform type consistency check

--- a/semantiva/payload_operations/pipeline_inspector.py
+++ b/semantiva/payload_operations/pipeline_inspector.py
@@ -1,6 +1,6 @@
 from typing import List, Any
-from .nodes import PipelineNode
 from semantiva.exceptions.pipeline import PipelineConfigurationError
+from .nodes.nodes import PipelineNode, ProbeContextInjectorNode, ContextProcessorNode
 
 
 class PipelineInspector:
@@ -94,8 +94,7 @@ class PipelineInspector:
         injected_or_created_keywords.update(created_keys)
 
         # If the node is a ProbeContextInjectorNode, add the context keyword to the set
-        if node.get_metadata().get("component_type") == "ProbeContextInjectorNode":
-            assert hasattr(node, "context_keyword")
+        if isinstance(node, ProbeContextInjectorNode):
             injected_or_created_keywords.add(node.context_keyword)
             created_keys.append(node.context_keyword)
             key_origin[node.context_keyword] = index
@@ -118,9 +117,8 @@ class PipelineInspector:
         ]
 
         # Add context suppressions if the node is a ContextProcessorNode
-        if node.get_metadata().get("component_type") == "ContextProcessorNode":
-            assert hasattr(node.processor, "get_suppressed_keys")
-            suppressed_keys = node.processor.get_suppressed_keys()
+        if isinstance(node, ContextProcessorNode):
+            suppressed_keys = node.get_suppressed_keys()
             deleted_keys.update(suppressed_keys)
             node_summary_lines.append(
                 f"\t\tContext suppressions: {cls._format_set(suppressed_keys)}"

--- a/semantiva/payload_operations/pipeline_inspector.py
+++ b/semantiva/payload_operations/pipeline_inspector.py
@@ -109,7 +109,7 @@ class PipelineInspector:
 
         # Build human-readable lines describing this node
         node_summary_lines = [
-            f"\n\t{index}. Node: {node.processor.__class__.__name__} ({node.__class__.__name__})",
+            f"\n\t{index}. Node: {node.processor.__class__.__name__} ({node.get_metadata().get('component_type', 'Unknown')})",
             f"\t\tParameters: {cls._format_set(operation_params)}",
             f"\t\t\tFrom pipeline configuration: {cls._format_pipeline_config(node.processor_config)}",
             f"\t\t\tFrom context: {cls._format_context_params(context_params, key_origin)}",

--- a/tests/test_pipeline_inspector.py
+++ b/tests/test_pipeline_inspector.py
@@ -3,13 +3,16 @@ from semantiva.payload_operations.pipeline import Pipeline
 from semantiva.payload_operations.pipeline_inspector import PipelineInspector
 from .test_utils import FloatMultiplyOperation, FloatCollectValueProbe
 
+
 @pytest.fixture
 def pipeline():
     """Generate a pipeline for testing."""
-    node_configuration = [{"processor": FloatCollectValueProbe, "context_keyword": "factor"},
-                          {"processor": FloatMultiplyOperation},
-                          {"processor": "rename:factor:renamed_key"},
-                          {"processor": "delete:renamed_key"},]
+    node_configuration = [
+        {"processor": FloatCollectValueProbe, "context_keyword": "factor"},
+        {"processor": FloatMultiplyOperation},
+        {"processor": "rename:factor:renamed_key"},
+        {"processor": "delete:renamed_key"},
+    ]
 
     pipeline = Pipeline(node_configuration)
     return pipeline
@@ -26,10 +29,8 @@ def test_pipeline_inspector(pipeline):
     assert "FloatCollectValueProbe" in inspection_report
     assert "FloatMultiplyOperation" in inspection_report
     assert "Context additions: factor" in inspection_report
-    assert "From context: factor (from Node 1)" in  inspection_report
+    assert "From context: factor (from Node 1)" in inspection_report
     assert "Context additions: renamed_key" in inspection_report
     assert "Context suppressions: factor" in inspection_report
     assert "Required context keys: None" in inspection_report
     assert "Context suppressions: renamed_key" in inspection_report
-
-


### PR DESCRIPTION
### Overview

This PR refactors the design of `node_factory.py` by moving the node class definitions out of the factory functions and into `nodes.py`. Previously, classes were dynamically created at runtime within factory methods, making them invisible to IDEs and static type checkers like mypy.

### Key Improvements

- **Enhanced Type Visibility:**
  - By defining classes explicitly in `nodes.py`, IDEs and mypy can now directly identify these classes, significantly improving static analysis capabilities.
  - Eliminates the need for runtime checks such as `assert hasattr(...)` to ensure type correctness, replacing them with clearer `isinstance` checks.

- **Metadata Generation:**
  - The factory functions now generate subclasses of the explicitly defined node classes, enriching them with `_define_metadata` based on the provided processor or data I/O class.

- **Reduction of Code Duplication:**
  - The common method `_process_single_item_with_context`, previously duplicated across multiple node classes, has been centralized in the `DataNode` base class.
  - Classes requiring specialized implementations of `_process_single_item_with_context` explicitly override this method using the `@override` decorator, clearly indicating their tailored behavior.

