### PR TITLE
Add license header management scripts and update CI pipeline

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -41,11 +41,15 @@ jobs:
       - name: Run mypy
         run: |
           pdm run mypy .
+          
+      - name: Check license headers
+        run: |
+          pdm run python scripts/check_license_headers.py
 
-      - name: Run black
+      - name: Run black    
         run: |
           pdm run black --check ${{ env.project_name }}
-
+    
   test:
     runs-on: ubuntu-latest
     needs: linting  # Ensure that the test job runs after linting job passes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,24 @@ This repository houses the Semantiva framework, a dual-channel pipeline system t
 
 ## Repository Layout
 
-* **`semantiva/`** - Core package containing the pipeline engine and reusable components.
-
-  * `core/` - Base classes like `SemantivaObject` for semantic metadata handling.
-  * `data_types/` - Minimal data containers used throughout the framework.
-  * `data_processors/` - Defines `DataOperation` and `DataProbe` along with factories for creating specialized versions.
-  * `context_processors/` - Utilities for manipulating the metadata context that travels alongside data.
-  * `pipeline/` - Pipeline orchestration, node definitions, and the `NodeFactory` for dynamic node creation.
-  * `tools/` - Command‑line helpers such as ontology export.
-  * `examples/` - Small demonstration modules and test utilities.
-* **`tests/`** - Pytest suite covering the various processors, nodes, and pipeline behaviours.
-* `CHANGELOG.md` and `README.md` - project history and overview
+* **semantiva/** - Core package containing the Semantiva framework:
+  * **component_loader/** - Dynamic loading of semantiva components.
+  * **configurations/** - Helpers to build pipelines from YAML configurations.
+  * **context_processors/** - Classes that manipulate pipeline context metadata.
+  * **core/** - Base classes (`SemantivaObject`) and semantic metadata registry.
+  * **data_io/** - Abstract data and payload sources and sinks.
+  * **data_processors/** - Definitions of data processors: `DataOperation`, `DataProbe`, slicers, and wrappers.
+  * **data_types/** - Minimal data containers used throughout the framework.
+  * **examples/** - Example processors and test utilities.
+  * **exceptions/** - Custom exception classes.
+  * **execution/** - Pipeline execution engine and job orchestration.
+  * **logger/** - Configurable logging helpers.
+  * **pipeline/** - Pipeline orchestration, node definitions, and `NodeFactory` for dynamic node creation.
+  * **specializations/** - Plugin loading for domain-specific extensions.
+  * **tools/** - Command-line utilities (e.g., ontology export, pipeline inspector).
+  * **utils/** - General-purpose helper functions.
+  * **workflows/** - Predefined workflow examples (e.g., model fitting).
+* **tests/** - Pytest suite covering processors, nodes, and pipeline behaviors.
 
 ## Architecture Overview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ Here is the updated changelog with the missing items included and the requested 
 ## [Unreleased] – TBD
 
 ### Added
-- Renamed `payload_operations` → `semantiva.pipeline` and `execution_tools` → `semantiva.execution`  
-- Added `Payload(data: BaseDataType, context: ContextType)` in `semantiva.pipeline.payload`  
+- Renamed `payload_operations` → `semantiva.pipeline` and `execution_tools` → `semantiva.execution`
+- Added `Payload(data: BaseDataType, context: ContextType)` in `semantiva.pipeline.payload`
 - New node types  
   - `DataOperationContextInjectorProbeNode`: runs a `DataOperation`, stores its output in the pipeline context under a specified key, and forwards the original data  
   - `ContextDataProcessorNode`: applies a `DataOperation` or `DataProbe` to a context value and writes the result back into context  
-- Factory methods  
-  - Exposed via `NodeFactory` to create the above node types  
+- Factory methods
+  - Exposed via `NodeFactory` to create the above node types
+ - Added `scripts/add_license.py` and `scripts/check_license_headers.py` for license header management
 
 ### Changed
 - Updated `PayloadSource`, `PayloadSink`, `Pipeline.process`, all node implementations, DataIO wrappers, examples and tests to use `Payload`  

--- a/ci_pipeline.sh
+++ b/ci_pipeline.sh
@@ -18,6 +18,8 @@ pdm run pylint semantiva --fail-under=7.5
 # Step 3: Run black (code formatting check)
 echo "Running black..."
 pdm run black --check semantiva
+echo "Running license header check..."
+pdm run python scripts/check_license_headers.py
 
 # Step 4: Run mypy
 echo "Running mypy"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,55 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env python3
+
+
+import re
+from typing import Iterable
+
+HEADER = """# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+HEADER_PATTERN = re.compile(
+    r"""^# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2\.0 \(the \"License\"\);
+# you may not use this file except in compliance with the License\.
+# You may obtain a copy of the License at
+#
+#     http://www\.apache\.org/licenses/LICENSE-2\.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.
+# See the License for the specific language governing permissions and
+# limitations under the License\.
+""",
+    re.MULTILINE,
+)
+
+INCLUDE_DIRS: Iterable[str] = ["semantiva", "tests", "scripts"]
+EXTENSIONS = [".py"]

--- a/scripts/add_license.py
+++ b/scripts/add_license.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility to prepend Apache 2.0 license headers to project files,
+    and report a summary of changes."""
+
+import os
+import re
+from scripts import HEADER, HEADER_PATTERN, INCLUDE_DIRS, EXTENSIONS
+
+
+def insert_header(filepath: str) -> bool:
+    """Insert license header if missing.
+    Returns True if the file was modified."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    if HEADER_PATTERN.search(content):
+        print(f"✅ Already has header: {filepath}")
+        return False
+
+    print(f"⚙️  Adding header: {filepath}")
+    header = HEADER.strip() + "\n"
+    new_content = header + ("\n" + content if content else "")
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+    return True
+
+
+def main() -> None:
+    changed_files = []
+
+    for dirpath in INCLUDE_DIRS:
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                if any(filename.endswith(ext) for ext in EXTENSIONS):
+                    fullpath = os.path.join(root, filename)
+                    if insert_header(fullpath):
+                        changed_files.append(fullpath)
+
+    print("\n✅ Done inserting headers.")
+    print(f"Total files updated: {len(changed_files)}")
+    if changed_files:
+        print("List of changed files:")
+        for path in changed_files:
+            print(f" - {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify that all project files contain the license header and summarize failures."""
+
+import os
+import sys
+
+from scripts import HEADER_PATTERN, INCLUDE_DIRS, EXTENSIONS
+
+
+def has_header(filepath: str) -> bool:
+    with open(filepath, "r", encoding="utf-8") as f:
+        return bool(HEADER_PATTERN.search(f.read()))
+
+
+def main() -> None:
+    missing_files = []
+
+    for dirpath in INCLUDE_DIRS:
+        for root, _, files in os.walk(dirpath):
+            for filename in files:
+                if any(filename.endswith(ext) for ext in EXTENSIONS):
+                    fullpath = os.path.join(root, filename)
+                    if not has_header(fullpath):
+                        print(f"❌ Missing header: {fullpath}")
+                        missing_files.append(fullpath)
+
+    print("\n✅ License check complete.")
+    print(f"Total files missing header: {len(missing_files)}")
+    if missing_files:
+        print("List of files without header:")
+        for path in missing_files:
+            print(f" - {path}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_license_scripts.py
+++ b/tests/test_license_scripts.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from scripts.add_license import insert_header, HEADER
+from scripts.check_license_headers import has_header
+
+
+def test_insert_header_no_extra_blank_line(tmp_path):
+    file_path = tmp_path / "__init__.py"
+    file_path.write_text("")
+    insert_header(str(file_path))
+    assert file_path.read_text() == HEADER.strip() + "\n"
+
+
+def test_check_file_has_header(tmp_path):
+    good = tmp_path / "good.py"
+    good.write_text(HEADER.strip() + "\n")
+    bad = tmp_path / "bad.py"
+    bad.write_text("print('hi')\n")
+    assert has_header(str(good))
+    assert not has_header(str(bad))

--- a/tests/test_string_specialization.py
+++ b/tests/test_string_specialization.py
@@ -16,6 +16,7 @@
 # Step 1: Define StringLiteralDataType
 #########################
 from semantiva.data_types import BaseDataType
+from semantiva.context_processors.context_types import ContextType
 
 
 class StringLiteralDataType(BaseDataType):
@@ -106,7 +107,7 @@ if __name__ == "__main__":
     input_data = StringLiteralDataType("World!")
 
     # 3. Run the pipeline
-    payload = pipeline.process(Payload(input_data, {}))
+    payload = pipeline.process(Payload(input_data, ContextType({})))
     output_data = payload.data
 
     # 4. Print final result
@@ -121,7 +122,7 @@ def test_string_specialization():
     input_data = StringLiteralDataType("World!")
 
     # 3. Run the pipeline
-    payload = pipeline.process(Payload(input_data, {}))
+    payload = pipeline.process(Payload(input_data, ContextType({})))
     output_data = payload.data
 
     # 4. Print final result


### PR DESCRIPTION
- Introduced `scripts/add_license.py` to prepend Apache 2.0 license headers to project files.
- Added `scripts/check_license_headers.py` to verify all project files contain the license header.
- Updated CI pipeline to include license header checks.
- Enhanced `AGENTS.md`  with new repository structure and features.