### PR TITLE
Enable use of default parameters in pipelines with full instrospection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Here is the updated changelog with the missing items included and the requested 
 ## [Unreleased] – TBD
 
 ### Added
+- Enable use of data processor parameter defaults with full introspection support
 - Renamed `payload_operations` → `semantiva.pipeline` and `execution_tools` → `semantiva.execution`
 - Added `Payload(data: BaseDataType, context: ContextType)` in `semantiva.pipeline.payload`
 - New node types  

--- a/semantiva/context_processors/context_processors.py
+++ b/semantiva/context_processors/context_processors.py
@@ -121,7 +121,7 @@ class ContextProcessor(_SemantivaComponent):
 
         component_metadata = {
             "component_type": "ContextProcessor",
-            "input_parameters": annotated_parameter_list or "None",
+            "parameters": annotated_parameter_list or "None",
         }
         return component_metadata
 

--- a/semantiva/core/semantiva_predicate_map.py
+++ b/semantiva/core/semantiva_predicate_map.py
@@ -29,7 +29,7 @@ EXPERIMENTAL_PREDICATE_MAP = {
     "class_name": SMTV.className,
     "component_type": SMTV.componentType,
     "docstring": SMTV.docString,
-    "input_parameters": SMTV.inputParameters,
+    "parameters": SMTV.parameters,
     "input_data_type": SMTV.inputDataType,
     "output_data_type": SMTV.outputDataType,
     "wraps_component_type": SMTV.wrapsComponentType,

--- a/semantiva/data_io/data_io.py
+++ b/semantiva/data_io/data_io.py
@@ -66,7 +66,7 @@ class DataSource(_SemantivaComponent):
 
         component_metadata = {
             "component_type": "DataSource",
-            "input_parameters": annotated_parameter_list or "None",
+            "parameters": annotated_parameter_list or "None",
         }
 
         try:
@@ -110,7 +110,7 @@ class PayloadSource(_SemantivaComponent):
 
         component_metadata = {
             "component_type": "PayloadSource",
-            "input_parameters": annotated_parameter_list,
+            "parameters": annotated_parameter_list,
             "injected_context_keys": cls.injected_context_keys(),
         }
 
@@ -219,7 +219,7 @@ class DataSink(_SemantivaComponent, Generic[T]):
 
         component_metadata = {
             "component_type": "DataSink",
-            "input_parameters": annotated_parameter_list or "None",
+            "parameters": annotated_parameter_list or "None",
         }
 
         try:
@@ -307,7 +307,7 @@ class PayloadSink(_SemantivaComponent, Generic[T]):
 
         component_metadata = {
             "component_type": "PayloadSink",
-            "input_parameters": annotated_parameter_list or "None",
+            "parameters": annotated_parameter_list or "None",
         }
 
         try:

--- a/semantiva/examples/test_utils.py
+++ b/semantiva/examples/test_utils.py
@@ -97,6 +97,13 @@ class FloatMultiplyOperation(FloatOperation):
         return FloatDataType(data.data * factor)
 
 
+class FloatMultiplyOperationWithDefault(FloatOperation):
+    """Multiply a Float by a factor with a default value of 2.0."""
+
+    def _process_logic(self, data, factor: float = 2.0):
+        return FloatDataType(data.data * factor)
+
+
 class FloatAddOperation(FloatOperation):
     """Add a constant to FloatDataType data."""
 
@@ -149,14 +156,14 @@ class FloatCollectionSumOperation(FloatCollectionMergeOperation):
 
 
 class FloatCollectValueProbe(FloatProbe):
-    """Collect the value of the provided FloatDataType data."""
+    """Collect the value of the input."""
 
     def _process_logic(self, data, *args, **kwargs):
         return data.data
 
 
 class FloatMockDataSource(DataSource):
-    """DataSource for 42.0 as a FloatDataType."""
+    """Float DataSource. Always produces the value 42.0."""
 
     @classmethod
     def _get_data(cls, *args, **kwargs) -> FloatDataType:

--- a/tests/test_default_parameters.py
+++ b/tests/test_default_parameters.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from semantiva.context_processors.context_types import ContextType
+from semantiva.pipeline import Payload
+from semantiva.pipeline.nodes._pipeline_node_factory import _pipeline_node_factory
+from semantiva.inspection import build_pipeline_inspection, summary_report, json_report
+from semantiva import Pipeline
+from semantiva.examples.test_utils import (
+    FloatDataType,
+    FloatMultiplyOperationWithDefault,
+    FloatMultiplyOperation,
+    FloatCollectValueProbe,
+)
+
+
+def test_runtime_fallback_to_default():
+    node = _pipeline_node_factory({"processor": FloatMultiplyOperationWithDefault})
+    payload = Payload(FloatDataType(3.0), ContextType())
+    result = node.process(payload)
+    assert result.data.data == 6.0
+
+
+def test_context_overrides_default():
+    node = _pipeline_node_factory({"processor": FloatMultiplyOperationWithDefault})
+    payload = Payload(FloatDataType(3.0), ContextType({"factor": 4.0}))
+    result = node.process(payload)
+    assert result.data.data == 12.0
+
+
+def test_missing_required_parameter_raises():
+    node = _pipeline_node_factory({"processor": FloatMultiplyOperation})
+    payload = Payload(FloatDataType(3.0), ContextType())
+    with pytest.raises(KeyError):
+        node.process(payload)
+
+
+def test_inspection_marks_default_and_user_params():
+    # Defaulted parameter
+    cfg_default = [{"processor": FloatMultiplyOperationWithDefault}]
+    inspection_default = build_pipeline_inspection(cfg_default)
+    report_default = summary_report(inspection_default)
+    assert "From processor defaults: factor=2.0" in report_default
+    assert "From pipeline configuration: None" in report_default
+    json_default = json_report(inspection_default)
+    assert (
+        json_default["nodes"][0]["parameter_resolution"]["from_processor_defaults"][
+            "factor"
+        ]
+        == "2.0"
+    )
+    assert not json_default["nodes"][0]["parameter_resolution"]["from_pipeline_config"]
+
+    # User override
+    cfg_user = [
+        {"processor": FloatMultiplyOperationWithDefault, "parameters": {"factor": 5.0}}
+    ]
+    inspection_user = build_pipeline_inspection(cfg_user)
+    report_user = summary_report(inspection_user)
+    assert "From pipeline configuration: factor=5.0" in report_user
+    assert "From processor defaults: None" in report_user
+    json_user = json_report(inspection_user)
+    assert (
+        json_user["nodes"][0]["parameter_resolution"]["from_pipeline_config"]["factor"]
+        == "5.0"
+    )
+    assert not json_user["nodes"][0]["parameter_resolution"]["from_processor_defaults"]
+
+
+def test_context_overrides_default_in_pipeline():
+    cfg = [
+        {"processor": FloatCollectValueProbe, "context_keyword": "factor"},
+        {"processor": FloatMultiplyOperationWithDefault},
+    ]
+
+    pipeline = Pipeline(cfg)
+    payload = Payload(FloatDataType(4.0), ContextType())
+    result = pipeline.process(payload)
+    assert result.data.data == 16.0
+
+    inspection = build_pipeline_inspection(cfg)
+    report = summary_report(inspection)
+    assert "From processor defaults: None" in report
+    assert "From context: factor (from Node 1)" in report
+
+    data = json_report(inspection)
+    node2 = data["nodes"][1]
+    assert not node2["parameter_resolution"]["from_processor_defaults"]
+    assert node2["parameter_resolution"]["from_context"]["factor"]["source_idx"] == 1

--- a/tests/test_pipeline_defaults.py
+++ b/tests/test_pipeline_defaults.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from semantiva.pipeline import Pipeline
+from semantiva.examples.test_utils import FloatDataType
+
+# Pipeline configuration matching test_pipeline_defaults.yaml
+pipeline_config = [
+    {"processor": "FloatMockDataSource"},
+    {"processor": "FloatMultiplyOperationWithDefault", "parameters": {"factor": 2.5}},
+    {"processor": "FloatMultiplyOperationWithDefault"},
+    {"processor": "FloatCollectValueProbe", "context_keyword": "factor"},
+    {"processor": "FloatMultiplyOperationWithDefault"},
+    {"processor": "rename:factor:dead_factor"},
+    {"processor": "FloatPayloadSink"},
+]
+
+
+def test_pipeline_defaults_execution():
+    pipeline = Pipeline(pipeline_config)
+    # Initial data is produced by FloatMockDataSource: 42.0
+    # Node 2: 42.0 * 2.5 = 105.0
+    # Node 3: 105.0 * 2.0 (default) = 210.0
+    # Node 4: factor = 210.0 injected into context
+    # Node 5: 210.0 * 210.0 (factor from context) = 44100.0
+    # Node 6: context key 'factor' renamed to 'dead_factor'
+    # Node 7: sink (no-op)
+    payload = pipeline.process()
+    # The final data should be 44100.0
+    assert isinstance(payload.data, FloatDataType)
+    assert payload.data.data == 44100.0
+    # The context should have 'dead_factor' with value 210.0, and no 'factor'
+    assert "dead_factor" in payload.context.keys()
+    assert payload.context.get_value("dead_factor") == 210.0
+    assert "factor" not in payload.context.keys()

--- a/tests/test_pipeline_defaults.yaml
+++ b/tests/test_pipeline_defaults.yaml
@@ -1,0 +1,12 @@
+pipeline:
+  nodes:
+  - processor: FloatMockDataSource
+  - processor: FloatMultiplyOperationWithDefault
+    parameters:
+      factor: 2.5
+  - processor: FloatMultiplyOperationWithDefault
+  - processor: FloatCollectValueProbe
+    context_keyword: factor
+  - processor: FloatMultiplyOperationWithDefault
+  - processor: rename:factor:dead_factor
+  - processor: FloatPayloadSink

--- a/tests/test_semantic_metadata.py
+++ b/tests/test_semantic_metadata.py
@@ -59,7 +59,7 @@ def test_payloadsink_semantic_metadata():
     print_metadata(FloatPayloadSink)
     assert FloatPayloadSink.get_metadata()["input_data_type"] == "FloatDataType"
     # Verify that 'payload' is not listed as a required parameter
-    assert FloatPayloadSink.get_metadata()["input_parameters"] == "None"
+    assert FloatPayloadSink.get_metadata()["parameters"] == "None"
 
 
 def test_float_multiply_operation_semantic_metadata():
@@ -67,9 +67,9 @@ def test_float_multiply_operation_semantic_metadata():
     print_metadata(FloatMultiplyOperation)
     assert FloatMultiplyOperation.get_metadata()["input_data_type"] == "FloatDataType"
     assert FloatMultiplyOperation.get_metadata()["output_data_type"] == "FloatDataType"
-    assert FloatMultiplyOperation.get_metadata()["input_parameters"] == [
-        "factor: float"
-    ]
+    params = FloatMultiplyOperation.get_metadata()["parameters"]
+    assert "factor" in params
+    assert params["factor"].annotation == "float"
 
 
 # test FloatProbe
@@ -77,7 +77,7 @@ def test_float_probe_semantic_metadata():
     """Test the semantic metadata of the FloatProbe"""
     print_metadata(FloatProbe)
     assert FloatProbe.get_metadata()["input_data_type"] == "FloatDataType"
-    assert FloatProbe.get_metadata()["input_parameters"] == "None"
+    assert FloatProbe.get_metadata()["parameters"] == {}
 
 
 def test_float_collection_sum_operation_semantic_metadata():
@@ -91,4 +91,4 @@ def test_float_collection_sum_operation_semantic_metadata():
         FloatCollectionSumOperation.get_metadata()["output_data_type"]
         == "FloatDataType"
     )
-    assert FloatCollectionSumOperation.get_metadata()["input_parameters"] == "None"
+    assert FloatCollectionSumOperation.get_metadata()["parameters"] == {}

--- a/tests/test_semantiva_object.py
+++ b/tests/test_semantiva_object.py
@@ -166,6 +166,7 @@ def test_semantic_id_metadata_consistency():
                     "docstring",
                     "wrapped_component_docstring",
                     # "class_name",
+                    "parameters",
                 ):
                     print(f"     Checking key '{key}', {value} in semantic_id")
                     if isinstance(value, list):


### PR DESCRIPTION
- Apply and inspect `_process_logic` signature defaults.
- Separate default parameters from pipeline config-provided parameters in reports.
- Update summary, extended, and JSON reports for clarity.
- Add tests to validate default parameter handling and reporting.