### PR TITLE
Unified execution/trace schema + fan-out v1; execution registry to break cycles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ This repository houses the Semantiva framework, a dual-channel pipeline system t
   * **data_types/** - Minimal data containers used throughout the framework.
   * **examples/** - Example processors and test utilities.
   * **exceptions/** - Custom exception classes.
-  * **execution/** - Pipeline execution engine and job orchestration.
+  * **execution/** - Pipeline execution engine and job orchestration:
+    * **component_registry.py** - Registry for orchestrators, executors, and transports to avoid circular imports.
+    * **orchestrator/** - Orchestrator implementations and factory for building from configuration.
   * **logger/** - Configurable logging helpers.
   * **pipeline/** - Pipeline orchestration, node definitions, and `NodeFactory` for dynamic node creation.
   * **tools/** - Command-line utilities (e.g., ontology export, pipeline inspector).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased] – TBD
 
 ### Added
+- Unified pipeline schema blocks (``execution``, ``trace``, ``fanout``) with
+  orchestration factory, fan-out expansion helper, CLI parity, documentation,
+  and tests covering SER fan-out pinning and local end-to-end runs.
+- **ExecutionComponentRegistry** for orchestrators/executors/transports with
+  lazy default registration to avoid circular imports; factory integration
+  for orchestrator construction.
 - Registry bootstrap profiles (``RegistryProfile``, ``apply_profile``,
   ``current_profile``) with SER ``registry.fingerprint`` pinning and
   documentation/examples for distributed bootstrap.
@@ -72,6 +78,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - Streamlined component docstrings per Semantiva guidelines for clean semantic identity
 
 ### Changed
+- CLI trace configuration replaced legacy flags with structured
+  ``--execution.*``, ``--trace.*``, and ``--fanout.*`` options aligned with the
+  YAML schema.
+- Consolidated registry documentation: merged the component registry architecture
+  into a unified ``Registry System`` page and updated cross-references.
 - ``ClassRegistry.initialize_default_modules()`` keeps user resolvers intact and
   installs built-ins only once; distributed orchestrators propagate registry
   profiles to workers before pipeline construction.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pipx install semantiva
 
 # Run the in-repo example pipeline and emit SER traces locally
 semantiva run semantiva/examples/simple_pipeline.yaml \
-  --trace-driver=jsonl --trace-output ./trace
+  --trace.driver=jsonl --trace.output ./trace
 
 # Inspect the installed version
 semantiva --version

--- a/docs/source/architecture/pipeline_schema.rst
+++ b/docs/source/architecture/pipeline_schema.rst
@@ -1,0 +1,63 @@
+Pipeline Configuration Schema
+=============================
+
+Semantiva pipeline YAML supports declarative configuration of execution and tracing
+behaviour alongside the node graph. The following optional top-level sections
+extend the base ``pipeline.nodes`` definition:
+
+``execution``
+   Resolve orchestrators, executors, and transports from the registry. When
+   omitted, the local sequential orchestrator with the in-memory transport is
+   used.
+
+   .. code-block:: yaml
+
+      execution:
+        orchestrator: LocalSemantivaOrchestrator
+        executor: SequentialSemantivaExecutor
+        transport: InMemorySemantivaTransport
+        options:
+          retries: 2
+
+``trace``
+   Configure tracing backends. The driver name is resolved via the registry,
+   with ``jsonl`` and ``none`` supported out of the box. ``output_path`` accepts
+   either a directory (a timestamped ``*.ser.jsonl`` file is created) or a
+   concrete file path. Arbitrary driver keyword arguments can be supplied via
+   ``options``.
+
+   .. code-block:: yaml
+
+      trace:
+        driver: jsonl
+        output_path: ./ser/run.ser.jsonl
+        options:
+          detail: all
+
+``fanout``
+   Declaratively expand a pipeline into multiple runs by injecting values into
+   the execution context. Two modes are supported:
+
+   ``param`` / ``values``
+      Single-parameter fan-out. Each value is injected into the context under
+      ``param`` for an independent run.
+
+   ``multi``
+      Multiple parameters zipped together. All lists must have equal length.
+
+   Values can be embedded inline or loaded from ``values_file`` (JSON or YAML).
+   The ``mode`` field is reserved for future expansion and currently defaults to
+   ``zip``.
+
+   .. code-block:: yaml
+
+      fanout:
+        multi:
+          value: [3.0, 5.0, 9.5]
+          factor: [2.0, 3.0, 5.0]
+
+Each fan-out run produces SER evidence with ``why_ok.args`` populated with the
+fan-out index, mode, injected values, and source metadata (including SHA-256
+hashes when values originate from external files). This guarantees reproducible
+audit trails for batch executions. See :doc:`../cli` for CLI flags mirroring the
+schema and :doc:`../examples_index` for runnable examples.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -30,9 +30,18 @@ Execute a pipeline.
                       [--context key=value]...
                       [-v | --verbose]
                       [-q | --quiet]
-                      [--trace-driver {none,jsonl,pythonpath}]
-                      [--trace-output PATH-or-DriverSpec]
-                     [--trace-detail FLAGS]
+                      [--execution.orchestrator CLASS]
+                      [--execution.executor CLASS]
+                      [--execution.transport CLASS]
+                      [--execution.option key=value]...
+                      [--trace.driver NAME]
+                      [--trace.output PATH-or-DriverSpec]
+                      [--trace.option key=value]...
+                      [--fanout.param NAME]
+                      [--fanout.values SEQ]
+                      [--fanout.values-file PATH]
+                      [--fanout.multi NAME=SEQ]...
+                      [--fanout.multi-file PATH]
                       [--version]
 
 **Arguments**
@@ -49,19 +58,26 @@ Execute a pipeline.
 
 - ``-v / --verbose``           Increase log verbosity.
 - ``-q / --quiet``             Only show errors.
-- ``--trace-driver``           ``none`` (default), ``jsonl``, or ``pythonpath``.
-- ``--trace-output``           For ``jsonl``, a file path; for ``pythonpath``, a driver spec
-  (``package.module:ClassName``) instantiated with no args.
-- ``--trace-detail``           Comma-separated flags: ``hash, repr, context, all``
-  (default: ``hash``).
+- ``--execution.orchestrator`` Resolve orchestrator by class name via the registry.
+- ``--execution.executor``     Resolve executor by class name via the registry.
+- ``--execution.transport``    Resolve transport by class name via the registry.
+- ``--execution.option``       Key/value pairs forwarded to the orchestrator ``options``.
+- ``--trace.driver``           Trace driver name (``none``, ``jsonl``, ``pythonpath``, or registry class).
+- ``--trace.output``           Trace output path or ``module:Class`` when ``driver=pythonpath``.
+- ``--trace.option``           Additional driver keyword arguments (repeatable).
+- ``--fanout.param``           Single-parameter fan-out target name.
+- ``--fanout.values``          Values for single-parameter fan-out (JSON list or comma-separated).
+- ``--fanout.values-file``     External JSON/YAML file supplying fan-out values.
+- ``--fanout.multi``           Multi-parameter ZIP values (repeatable ``name=[...]`` arguments).
+- ``--fanout.multi-file``      External JSON/YAML mapping supplying multi fan-out values.
 - ``--version``                Show CLI version.
 
-Environment pins and pre/post check results are always included in every
-SER regardless of the ``--trace-detail`` flags; the flags only control the
-additional summary hashes and representations. This behaviour is implemented
-once in :py:class:`~semantiva.execution.orchestrator.orchestrator.SemantivaOrchestrator`,
-so every orchestrator used by the CLI (local now, remote later) produces the
-same evidence layout.
+CLI flags mirror the YAML schema. Any value provided on the command line
+overrides the matching YAML block before validation and execution. Trace detail
+flags are supplied via ``--trace.option detail=...`` (``hash`` is implied when no
+options are provided). Environment pins and why-ok invariants are always
+captured by :py:class:`~semantiva.execution.orchestrator.orchestrator.SemantivaOrchestrator`,
+ensuring consistent SER output across orchestrator implementations.
 
 **YAML Extension Loading**
 If your YAML contains:

--- a/docs/source/examples/fanout_basic_local.yaml
+++ b/docs/source/examples/fanout_basic_local.yaml
@@ -1,0 +1,18 @@
+extensions: []
+
+pipeline:
+  nodes:
+    - processor: FloatValueDataSource
+    - processor: FloatMultiplyOperation
+    - processor: FloatMockDataSink
+      parameters:
+        path: ./fanout-output.txt
+
+trace:
+  driver: jsonl
+  output_path: ./ser/fanout-run-local.ser.jsonl
+
+fanout:
+  multi:
+    value: [3.0, 5.0, 9.5]
+    factor: [2.0, 3.0, 5.0]

--- a/docs/source/execution.rst
+++ b/docs/source/execution.rst
@@ -5,6 +5,25 @@ The execution module provides the orchestration infrastructure for running Seman
 It includes comprehensive error handling and integration with the tracing system to capture
 complete execution records, including error events with timing data and exception details.
 
+Component Registry System
+--------------------------
+
+Semantiva uses a dual-registry architecture to manage execution components while avoiding
+circular import dependencies:
+
+:py:class:`~semantiva.execution.component_registry.ExecutionComponentRegistry`
+    Specialized registry for orchestrators, executors, and transports. This registry
+    is designed to break circular import dependencies with the main ClassRegistry
+    and graph builder modules.
+
+:py:func:`~semantiva.execution.orchestrator.factory.build_orchestrator`
+    Factory function that uses ExecutionComponentRegistry to construct orchestrators
+    from configuration, supporting dependency injection of executors and transports.
+
+The component registry follows the dependency inversion principle, acting as a dependency
+sink rather than creating webs of interdependence. See :doc:`architecture/registry`
+for detailed architectural information.
+
 Template-method orchestrator
 ----------------------------
 
@@ -27,6 +46,8 @@ executor/transport while benefiting from the shared SER logic.
 Public API Surface
 ------------------
 
+- Component Registry: :py:mod:`semantiva.execution.component_registry`
+- Orchestrator Factory: :py:mod:`semantiva.execution.orchestrator.factory`
 - Executors: :py:mod:`semantiva.execution.executor.executor`
 - Orchestrators: :py:mod:`semantiva.execution.orchestrator.orchestrator`
 - Transports: :py:mod:`semantiva.execution.transport.in_memory`
@@ -34,6 +55,14 @@ Public API Surface
 
 Autodoc
 -------
+
+.. automodule:: semantiva.execution.component_registry
+   :members:
+   :undoc-members:
+
+.. automodule:: semantiva.execution.orchestrator.factory
+   :members:
+   :undoc-members:
 
 .. automodule:: semantiva.execution.executor.executor
    :members:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -49,7 +49,7 @@ You can also run the pipeline with tracing enabled.
 
 .. code-block:: bash
 
-   semantiva run hello_pipeline.yaml --trace-driver jsonl --trace-detail all --trace-output traces/
+   semantiva run hello_pipeline.yaml --trace.driver jsonl --trace.option detail=all --trace.output traces/
 
 This command will produce detailed execution traces.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ Semantiva is a semantic execution framework focused on **typed, transparent, ins
    graph
    architecture/registry
    architecture/context_processing
+   architecture/pipeline_schema
    execution
    workflows_fitting_models
    logger

--- a/semantiva/configurations/__init__.py
+++ b/semantiva/configurations/__init__.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .load_pipeline_from_yaml import load_pipeline_from_yaml
+from .load_pipeline_from_yaml import load_pipeline_from_yaml, parse_pipeline_config
+from .schema import ExecutionConfig, TraceConfig, FanoutSpec, PipelineConfiguration
 
 __all__ = [
     "load_pipeline_from_yaml",
+    "parse_pipeline_config",
+    "ExecutionConfig",
+    "TraceConfig",
+    "FanoutSpec",
+    "PipelineConfiguration",
 ]

--- a/semantiva/configurations/load_pipeline_from_yaml.py
+++ b/semantiva/configurations/load_pipeline_from_yaml.py
@@ -12,125 +12,163 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-YAML Pipeline Configuration Loader
-==================================
+"""YAML loader returning structured pipeline configuration objects."""
 
-This module provides functionality to load Semantiva pipeline configurations
-from YAML files with automatic extension loading support.
+from __future__ import annotations
 
-YAML Structure:
---------------
-```yaml
-# Optional: Load extensions before parsing processors
-extensions: ["semantiva_imaging"]  # or "single_package"
-
-pipeline:
-  nodes:
-    - processor: "ProcessorName"
-      parameters:
-        param1: value1
-    - processor: "delete:context_key"
-    - processor: "slicer:Processor:Collection"
-```
-
-Extension Loading:
-----------------------
-Extensions can be specified at top-level or under pipeline section.
-They are loaded before processing node definitions.
-
-Usage:
-------
-```python
-from semantiva.configurations import load_pipeline_from_yaml
-nodes = load_pipeline_from_yaml("pipeline.yaml")
-```
-"""
+from pathlib import Path
+from typing import Any, Iterable, Mapping
 
 import yaml
-from typing import List, Dict, Any
+
 from semantiva.registry import load_extensions
 from semantiva.registry.class_registry import ClassRegistry
 
+from .schema import ExecutionConfig, FanoutSpec, PipelineConfiguration, TraceConfig
 
-def load_pipeline_from_yaml(yaml_file: str) -> List[Dict[str, Any]]:
-    """Load a Semantiva pipeline configuration from a YAML file.
 
-    This function parses a YAML file containing a pipeline definition and
-    automatically loads any specified extensions before returning the
-    node configurations. This enables seamless integration of domain-specific
-    processors and data types in pipeline definitions.
+def _ensure_mapping(name: str, value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"'{name}' block must be a mapping if provided")
+    return value
 
-    Args:
-        yaml_file: Path to the YAML file containing the pipeline configuration.
 
-    Returns:
-        List[Dict[str, Any]]: A list of dictionaries, where each dictionary
-            represents a single pipeline node configuration. Each node dict
-            typically contains:
-            - 'processor': The name/type of the processor to instantiate
-            - 'parameters': Optional dict of parameters for the processor
-            - Other node-specific configuration keys
+def _parse_execution_block(block: Any) -> ExecutionConfig:
+    data = _ensure_mapping("execution", block)
+    options = data.get("options") or {}
+    if options is None:
+        options = {}
+    if not isinstance(options, Mapping):
+        raise ValueError("execution.options must be a mapping")
+    return ExecutionConfig(
+        orchestrator=data.get("orchestrator"),
+        executor=data.get("executor"),
+        transport=data.get("transport"),
+        options=dict(options),
+    )
 
-    Raises:
-        ValueError: If the YAML file is missing required structure:
-                   - Missing 'pipeline' top-level key
-                   - Missing 'nodes' key under 'pipeline'
-                   - Invalid nested structure (non-dict objects where dicts expected)
-        FileNotFoundError: If the specified YAML file cannot be found
-        yaml.YAMLError: If the file contains invalid YAML syntax
 
-    YAML Structure:
-        The function expects this structure:
-        ```yaml
-        # Optional extensions (top-level or under pipeline)
-        extensions: ["package1", "package2"] | "single_package"
+def _parse_trace_block(block: Any) -> TraceConfig:
+    data = _ensure_mapping("trace", block)
+    options = data.get("options") or {}
+    if options is None:
+        options = {}
+    if not isinstance(options, Mapping):
+        raise ValueError("trace.options must be a mapping")
+    return TraceConfig(
+        driver=data.get("driver"),
+        output_path=data.get("output_path"),
+        options=dict(options),
+    )
 
-        pipeline:
-          nodes:
-            - processor: "ProcessorName"
-              parameters: {...}
-            - processor: "AnotherProcessor"
-        ```
 
-    Note:
-        This function only loads and returns the node configurations. It does
-        not instantiate the actual Pipeline object or validate that all
-        specified processors are available. Use with `Pipeline(nodes)` to
-        create an executable pipeline.
-    """
-    # Ensure core components and example utilities are registered so that
-    # processor class names referenced in YAML (e.g. FloatValueDataSource)
-    # can be resolved by the ClassRegistry during pipeline loading.
-    ClassRegistry.initialize_default_modules()
+def _parse_fanout_block(block: Any) -> FanoutSpec:
+    if block is None:
+        return FanoutSpec()
+    if not isinstance(block, Mapping):
+        raise ValueError("fanout block must be a mapping if provided")
+    spec = FanoutSpec()
+    if "param" in block:
+        spec.param = block.get("param")
+    if "values" in block:
+        values = block.get("values")
+        if values is not None and not isinstance(values, list):
+            raise ValueError("fanout.values must be a list")
+        spec.values = list(values) if values is not None else None
+    if "values_file" in block:
+        vf = block.get("values_file")
+        if vf is not None and not isinstance(vf, str):
+            raise ValueError("fanout.values_file must be a string path")
+        spec.values_file = vf
+    multi = block.get("multi")
+    if multi is not None:
+        if not isinstance(multi, Mapping):
+            raise ValueError("fanout.multi must be a mapping of parameter -> list")
+        spec.multi = {}
+        for key, seq in multi.items():
+            if not isinstance(seq, list):
+                raise ValueError("fanout.multi entries must be lists")
+            spec.multi[str(key)] = list(seq)
+    if "mode" in block:
+        spec.mode = str(block.get("mode") or "zip")
+    return spec
 
-    with open(yaml_file, "r", encoding="utf-8") as file:
-        pipeline_config = yaml.safe_load(file)
 
-    # Load extensions if provided in YAML
-    if isinstance(pipeline_config, dict):
-        # Check top-level extensions first
-        specs = pipeline_config.get("extensions")
+def _extract_extensions(config: Mapping[str, Any]) -> Iterable[str]:
+    top_level = config.get("extensions")
+    if top_level:
+        if isinstance(top_level, (list, tuple)):
+            return list(top_level)
+        return [top_level]
+    pipeline_block = config.get("pipeline")
+    if isinstance(pipeline_block, Mapping):
+        nested = pipeline_block.get("extensions")
+        if nested:
+            if isinstance(nested, (list, tuple)):
+                return list(nested)
+            return [nested]
+    return []
 
-        # If not found, check under pipeline section
-        if not specs and isinstance(pipeline_config.get("pipeline"), dict):
-            specs = pipeline_config["pipeline"].get("extensions")
 
-        # Load extensions if any were found
-        if specs:
-            load_extensions(specs)
+def parse_pipeline_config(
+    config: Mapping[str, Any],
+    *,
+    source_path: str | None = None,
+    base_dir: Path | None = None,
+) -> PipelineConfiguration:
+    """Convert a raw mapping into a :class:`PipelineConfiguration`."""
 
-    # Validate required YAML structure
     if (
-        not isinstance(pipeline_config, dict)
-        or "pipeline" not in pipeline_config
-        or not isinstance(pipeline_config["pipeline"], dict)
-        or "nodes" not in pipeline_config["pipeline"]
+        not isinstance(config, Mapping)
+        or "pipeline" not in config
+        or not isinstance(config["pipeline"], Mapping)
+        or "nodes" not in config["pipeline"]
     ):
         raise ValueError(
             "Invalid pipeline configuration: YAML file must contain a 'pipeline' "
-            "section with a 'nodes' list. Expected structure:\n"
-            "pipeline:\n  nodes:\n    - processor: 'ProcessorName'"
+            "section with a 'nodes' list."
         )
 
-    return pipeline_config["pipeline"]["nodes"]
+    ClassRegistry.initialize_default_modules()
+
+    extensions = list(_extract_extensions(config))
+    if extensions:
+        load_extensions(extensions)
+
+    nodes = config["pipeline"]["nodes"]
+    if not isinstance(nodes, list) or not all(isinstance(n, Mapping) for n in nodes):
+        raise ValueError("pipeline.nodes must be a list of mappings")
+
+    execution_cfg = _parse_execution_block(config.get("execution"))
+    trace_cfg = _parse_trace_block(config.get("trace"))
+    fanout_cfg = _parse_fanout_block(config.get("fanout"))
+
+    return PipelineConfiguration(
+        [dict(node) for node in nodes],
+        execution=execution_cfg,
+        trace=trace_cfg,
+        fanout=fanout_cfg,
+        extensions=extensions,
+        source_path=source_path,
+        base_dir=base_dir,
+        raw=dict(config),
+    )
+
+
+def load_pipeline_from_yaml(yaml_file: str) -> PipelineConfiguration:
+    """Load a Semantiva pipeline configuration from a YAML file."""
+
+    path = Path(yaml_file).expanduser().resolve()
+    with path.open("r", encoding="utf-8") as file:
+        pipeline_config = yaml.safe_load(file)
+
+    return parse_pipeline_config(
+        pipeline_config or {},
+        source_path=str(path),
+        base_dir=path.parent,
+    )
+
+
+__all__ = ["load_pipeline_from_yaml", "parse_pipeline_config"]

--- a/semantiva/configurations/schema.py
+++ b/semantiva/configurations/schema.py
@@ -1,0 +1,89 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structured configuration objects for YAML and CLI entry points."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+
+@dataclass
+class ExecutionConfig:
+    """Configuration for orchestrator, executor, and transport resolution."""
+
+    orchestrator: Optional[str] = None
+    executor: Optional[str] = None
+    transport: Optional[str] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TraceConfig:
+    """Configuration for trace driver construction."""
+
+    driver: Optional[str] = None
+    output_path: Optional[str] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FanoutSpec:
+    """Declarative fan-out specification supporting single and multi-zip modes."""
+
+    param: Optional[str] = None
+    values: Optional[List[Any]] = None
+    values_file: Optional[str] = None
+    multi: Dict[str, List[Any]] = field(default_factory=dict)
+    mode: str = "zip"
+
+
+class PipelineConfiguration(list[dict[str, Any]]):
+    """List-like pipeline configuration enriched with execution metadata."""
+
+    def __init__(
+        self,
+        nodes: Sequence[dict[str, Any]],
+        *,
+        execution: Optional[ExecutionConfig] = None,
+        trace: Optional[TraceConfig] = None,
+        fanout: Optional[FanoutSpec] = None,
+        extensions: Optional[Iterable[str]] = None,
+        source_path: Optional[str] = None,
+        base_dir: Optional[Path] = None,
+        raw: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(nodes)
+        self.execution = execution or ExecutionConfig()
+        self.trace = trace or TraceConfig()
+        self.fanout = fanout or FanoutSpec()
+        self.extensions = tuple(extensions or ())
+        self.source_path = source_path
+        self.base_dir = Path(base_dir) if base_dir is not None else None
+        self.raw = dict(raw or {})
+
+    @property
+    def nodes(self) -> List[dict[str, Any]]:
+        """Return the pipeline nodes as a list for ergonomic access."""
+
+        return list(self)
+
+
+__all__ = [
+    "ExecutionConfig",
+    "TraceConfig",
+    "FanoutSpec",
+    "PipelineConfiguration",
+]

--- a/semantiva/execution/component_registry.py
+++ b/semantiva/execution/component_registry.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execution Component Registry for orchestrators, executors, and transports.
+
+This module provides a registry specifically for execution components to avoid
+circular import dependencies with the main ClassRegistry and graph builder modules.
+The registry follows the dependency inversion principle by being a dependency sink
+rather than creating webs of interdependence.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Type
+
+from semantiva.logger import Logger
+
+
+class ExecutionComponentRegistry:
+    """Registry for execution layer components: orchestrators, executors, transports.
+
+    This registry is designed to break circular import dependencies by providing
+    a dedicated registration system for execution components that doesn't depend
+    on graph building or general class resolution functionality.
+    """
+
+    _orchestrators: Dict[str, Type] = {}
+    _executors: Dict[str, Type] = {}
+    _transports: Dict[str, Type] = {}
+    _initialized: bool = False
+
+    @classmethod
+    def register_orchestrator(cls, name: str, orchestrator_cls: Type) -> None:
+        """Register an orchestrator class by name.
+
+        Args:
+            name: String identifier for the orchestrator
+            orchestrator_cls: The orchestrator class to register
+        """
+        cls._orchestrators[name] = orchestrator_cls
+        Logger().debug(f"Registered orchestrator: {name}")
+
+    @classmethod
+    def register_executor(cls, name: str, executor_cls: Type) -> None:
+        """Register an executor class by name.
+
+        Args:
+            name: String identifier for the executor
+            executor_cls: The executor class to register
+        """
+        cls._executors[name] = executor_cls
+        Logger().debug(f"Registered executor: {name}")
+
+    @classmethod
+    def register_transport(cls, name: str, transport_cls: Type) -> None:
+        """Register a transport class by name.
+
+        Args:
+            name: String identifier for the transport
+            transport_cls: The transport class to register
+        """
+        cls._transports[name] = transport_cls
+        Logger().debug(f"Registered transport: {name}")
+
+    @classmethod
+    def get_orchestrator(cls, name: str) -> Optional[Type]:
+        """Get an orchestrator class by name.
+
+        Args:
+            name: String identifier for the orchestrator
+
+        Returns:
+            The orchestrator class or None if not found
+        """
+        return cls._orchestrators.get(name)
+
+    @classmethod
+    def get_executor(cls, name: str) -> Optional[Type]:
+        """Get an executor class by name.
+
+        Args:
+            name: String identifier for the executor
+
+        Returns:
+            The executor class or None if not found
+        """
+        return cls._executors.get(name)
+
+    @classmethod
+    def get_transport(cls, name: str) -> Optional[Type]:
+        """Get a transport class by name.
+
+        Args:
+            name: String identifier for the transport
+
+        Returns:
+            The transport class or None if not found
+        """
+        return cls._transports.get(name)
+
+    @classmethod
+    def initialize_defaults(cls) -> None:
+        """Initialize default execution components.
+
+        This method registers the built-in orchestrators, executors, and transports.
+        It's designed to be called after other modules are loaded to avoid circular
+        import issues.
+
+        Safe to call multiple times - subsequent calls are idempotent.
+        """
+        if cls._initialized:
+            return
+
+        # Import here to avoid circular dependencies
+        from .orchestrator.orchestrator import (
+            LocalSemantivaOrchestrator,
+            SemantivaOrchestrator,
+        )
+        from .executor.executor import SequentialSemantivaExecutor
+        from .transport import InMemorySemantivaTransport
+
+        # Register default orchestrators
+        cls.register_orchestrator(
+            "LocalSemantivaOrchestrator", LocalSemantivaOrchestrator
+        )
+        cls.register_orchestrator("SemantivaOrchestrator", SemantivaOrchestrator)
+
+        # Register default executors
+        cls.register_executor(
+            "SequentialSemantivaExecutor", SequentialSemantivaExecutor
+        )
+
+        # Register default transports
+        cls.register_transport("InMemorySemantivaTransport", InMemorySemantivaTransport)
+
+        cls._initialized = True
+        Logger().debug("ExecutionComponentRegistry initialized with defaults")
+
+    @classmethod
+    def get_registered_orchestrators(cls) -> Dict[str, Type]:
+        """Get all registered orchestrators."""
+        return dict(cls._orchestrators)
+
+    @classmethod
+    def get_registered_executors(cls) -> Dict[str, Type]:
+        """Get all registered executors."""
+        return dict(cls._executors)
+
+    @classmethod
+    def get_registered_transports(cls) -> Dict[str, Type]:
+        """Get all registered transports."""
+        return dict(cls._transports)
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registered components. Primarily for testing."""
+        cls._orchestrators.clear()
+        cls._executors.clear()
+        cls._transports.clear()
+        cls._initialized = False
+
+
+__all__ = ["ExecutionComponentRegistry"]

--- a/semantiva/execution/fanout.py
+++ b/semantiva/execution/fanout.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for expanding declarative fan-out specifications."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+from semantiva.configurations.schema import FanoutSpec
+from semantiva.exceptions.pipeline_exceptions import (
+    PipelineConfigurationError as ConfigurationError,
+)
+
+
+def _sha256_bytes(data: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def _load_values_file(path: Path) -> tuple[Any, str]:
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError as exc:  # pragma: no cover - path errors bubble up
+        raise ConfigurationError(f"fanout values file not found: {path}") from exc
+    if path.suffix.lower() == ".json":
+        payload = json.loads(data.decode("utf-8"))
+    else:
+        payload = yaml.safe_load(data)  # type: ignore[no-untyped-call]
+    return payload, _sha256_bytes(data)
+
+
+def expand_fanout(
+    spec: FanoutSpec,
+    *,
+    cwd: str | Path = ".",
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Expand ``FanoutSpec`` into per-run context injections and metadata."""
+
+    meta: Dict[str, Any] = {}
+    payload: Any = None
+    base_path = Path(cwd)
+
+    if spec.values_file:
+        payload, sha = _load_values_file(base_path / spec.values_file)
+        meta["source_file"] = spec.values_file
+        meta["source_sha256"] = sha
+
+    # Single parameter fan-out -------------------------------------------------
+    if spec.param:
+        values = spec.values if spec.values is not None else payload
+        if values is None:
+            raise ConfigurationError(
+                "fanout.param requires 'values' or 'values_file' to provide a list"
+            )
+        if not isinstance(values, list):
+            raise ConfigurationError(
+                "fanout.values (or loaded values_file) must be a list for single-param fan-out"
+            )
+        runs = [{spec.param: value} for value in values]
+        meta["mode"] = "single"
+        return runs, meta
+
+    # Multi parameter fan-out --------------------------------------------------
+    multi_spec: Dict[str, List[Any]] = {}
+    if spec.multi:
+        multi_spec.update(spec.multi)
+    elif isinstance(payload, dict):
+        multi_spec.update(payload)
+
+    if not multi_spec:
+        meta["mode"] = "none"
+        return [], meta
+
+    lengths = {key: len(value) for key, value in multi_spec.items()}
+    if len(set(lengths.values())) != 1:
+        raise ConfigurationError(
+            "fanout.multi lists must have identical size; got lengths " + str(lengths)
+        )
+    count = next(iter(lengths.values())) if lengths else 0
+    runs_multi: List[Dict[str, Any]] = []
+    for index in range(count):
+        runs_multi.append({key: multi_spec[key][index] for key in multi_spec})
+
+    meta["mode"] = "multi_zip"
+    return runs_multi, meta
+
+
+__all__ = ["expand_fanout"]

--- a/semantiva/execution/orchestrator/factory.py
+++ b/semantiva/execution/orchestrator/factory.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Factory utilities for constructing orchestrators from configuration."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from semantiva.configurations.schema import ExecutionConfig
+from ..component_registry import ExecutionComponentRegistry
+
+
+def _instantiate_if_present(name: str | None, component_type: str) -> Any | None:
+    if not name:
+        return None
+
+    if component_type == "orchestrator":
+        cls = ExecutionComponentRegistry.get_orchestrator(name)
+    elif component_type == "executor":
+        cls = ExecutionComponentRegistry.get_executor(name)
+    elif component_type == "transport":
+        cls = ExecutionComponentRegistry.get_transport(name)
+    else:
+        raise ValueError(f"Unknown component type: {component_type}")
+
+    if cls is None:
+        raise ValueError(f"Unknown {component_type}: {name}")
+
+    return cls()
+
+
+def _attempt_construct(cls: type, kwargs: Dict[str, Any]) -> Any:
+    attempt_order = [
+        dict(kwargs),
+        {k: v for k, v in kwargs.items() if k != "options"},
+        {k: v for k, v in kwargs.items() if k not in {"options", "transport"}},
+        {
+            k: v
+            for k, v in kwargs.items()
+            if k not in {"options", "transport", "executor"}
+        },
+        {},
+    ]
+    last_error: Exception | None = None
+    for candidate in attempt_order:
+        try:
+            return cls(**candidate)
+        except TypeError as exc:
+            last_error = exc
+            continue
+    if last_error:
+        raise last_error
+    return cls()
+
+
+def build_orchestrator(
+    exec_cfg: ExecutionConfig,
+    *,
+    transport: Any | None = None,
+    executor: Any | None = None,
+):
+    """Construct an orchestrator respecting explicit transport and executor.
+
+    This factory function uses the ExecutionComponentRegistry to resolve orchestrator,
+    executor, and transport classes by name, then constructs them with dependency
+    injection. It provides graceful fallbacks for constructor argument compatibility.
+
+    Args:
+        exec_cfg: Execution configuration containing component names and options
+        transport: Optional transport instance to inject (overrides config)
+        executor: Optional executor instance to inject (overrides config)
+
+    Returns:
+        Configured orchestrator instance with injected dependencies
+
+    Raises:
+        ValueError: If specified component names are not found in registry
+        TypeError: If component construction fails with all argument combinations
+
+    Example:
+        >>> from semantiva.configurations.schema import ExecutionConfig
+        >>> config = ExecutionConfig(orchestrator="LocalSemantivaOrchestrator")
+        >>> orchestrator = build_orchestrator(config)
+    """
+
+    transport_obj = transport or _instantiate_if_present(
+        exec_cfg.transport, "transport"
+    )
+    executor_obj = executor or _instantiate_if_present(exec_cfg.executor, "executor")
+
+    if exec_cfg.orchestrator:
+        orch_cls = ExecutionComponentRegistry.get_orchestrator(exec_cfg.orchestrator)
+        if orch_cls is None:
+            raise ValueError(f"Unknown orchestrator: {exec_cfg.orchestrator}")
+    else:
+        from .orchestrator import LocalSemantivaOrchestrator
+
+        orch_cls = LocalSemantivaOrchestrator
+
+    kwargs: Dict[str, Any] = {}
+    if transport_obj is not None:
+        kwargs["transport"] = transport_obj
+    if executor_obj is not None:
+        kwargs["executor"] = executor_obj
+    if exec_cfg.options:
+        kwargs["options"] = exec_cfg.options
+
+    orchestrator = _attempt_construct(orch_cls, kwargs)
+    return orchestrator
+
+
+__all__ = ["build_orchestrator"]

--- a/semantiva/registry/class_registry.py
+++ b/semantiva/registry/class_registry.py
@@ -24,6 +24,11 @@ prefix-based resolution. This is essential for pipeline definitions that use
 text-based configuration (e.g., YAML) to specify processor types, including
 special cases like renaming, deletion, slicing, or parametric sweep operations.
 
+Note: This registry handles data processors, context processors, and workflow
+components. Execution layer components (orchestrators, executors, transports)
+are managed by :py:class:`~semantiva.execution.component_registry.ExecutionComponentRegistry`
+to avoid circular import dependencies.
+
 Custom Resolver System
 ---------------------
 The registry supports pluggable resolvers via the `register_resolver` API. A
@@ -170,6 +175,18 @@ class ClassRegistry:
                 if resolver not in cls._custom_resolvers:
                     cls._custom_resolvers.append(resolver)
             cls._builtin_resolver_names.add(name)
+
+        # Initialize execution components after core modules are loaded
+        # This avoids circular import issues
+        try:
+            from semantiva.execution.component_registry import (
+                ExecutionComponentRegistry,
+            )
+
+            ExecutionComponentRegistry.initialize_defaults()
+        except ImportError:
+            # ExecutionComponentRegistry might not be available in all contexts
+            pass
 
         cls._initialized_defaults = True
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,7 @@ def test_cli_run_success(tmp_path: Path):
     res = run_cli(["run", str(yaml_path)])
     assert res.returncode == 0
     assert output_file.read_text().strip() == "84.0"
-    assert "Completed" in res.stdout
+    assert "Run 1/1 completed" in res.stdout
 
 
 def test_cli_file_not_found():
@@ -67,6 +67,8 @@ def test_cli_validate(tmp_path: Path):
               parameters:
                 factor: 2.0
             - processor: FloatMockDataSink
+              parameters:
+                path: "/tmp/out.txt"
         """,
     )
     invalid = make_pipeline(tmp_path, "pipeline:\n  bad: true\n", name="invalid.yaml")

--- a/tests/test_cli_pipeline_model_fitting_jsonl.py
+++ b/tests/test_cli_pipeline_model_fitting_jsonl.py
@@ -30,11 +30,11 @@ def test_cli_pipeline_model_fitting_jsonl(tmp_path: Path):
         [
             "run",
             "tests/pipeline_model_fitting.yaml",
-            "--trace-driver",
+            "--trace.driver",
             "jsonl",
-            "--trace-detail",
-            "all",
-            "--trace-output",
+            "--trace.option",
+            "detail=all",
+            "--trace.output",
             str(output_dir),
             "--context",
             "x_values=[0,1,2]",
@@ -71,9 +71,9 @@ pipeline:
         [
             "run",
             str(yaml_path),
-            "--trace-driver",
+            "--trace.driver",
             "jsonl",
-            "--trace-output",
+            "--trace.output",
             str(output_dir),
         ]
     )

--- a/tests/test_fanout_expansion.py
+++ b/tests/test_fanout_expansion.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from semantiva.configurations.schema import FanoutSpec
+from semantiva.execution.fanout import expand_fanout
+from semantiva.exceptions.pipeline_exceptions import PipelineConfigurationError
+
+
+def test_single_param_expansion_order_and_values():
+    spec = FanoutSpec(param="value", values=[3, 5, 9])
+    runs, meta = expand_fanout(spec)
+    assert runs == [{"value": 3}, {"value": 5}, {"value": 9}]
+    assert meta["mode"] == "single"
+
+
+def test_multi_zip_requires_equal_lengths():
+    spec = FanoutSpec(multi={"value": [1, 2], "factor": [2]})
+    with pytest.raises(PipelineConfigurationError):
+        expand_fanout(spec)
+
+
+def test_multi_zip_expands_deterministically():
+    spec = FanoutSpec(multi={"value": [3, 5, 9], "factor": [2, 3, 5]})
+    runs, meta = expand_fanout(spec)
+    assert runs[0] == {"value": 3, "factor": 2}
+    assert runs[1] == {"value": 5, "factor": 3}
+    assert runs[2] == {"value": 9, "factor": 5}
+    assert meta["mode"] == "multi_zip"
+
+
+def test_single_param_values_file(tmp_path):
+    values_path = tmp_path / "values.json"
+    values_path.write_text(json.dumps([1, 2, 3]))
+    spec = FanoutSpec(param="value", values_file=values_path.name)
+    runs, meta = expand_fanout(spec, cwd=tmp_path)
+    assert [entry["value"] for entry in runs] == [1, 2, 3]
+    assert meta["source_file"] == values_path.name
+    assert "source_sha256" in meta

--- a/tests/test_fanout_local_e2e.py
+++ b/tests/test_fanout_local_e2e.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from semantiva import Pipeline, Payload
+from semantiva.configurations import load_pipeline_from_yaml
+from semantiva.context_processors import ContextType
+from semantiva.data_types import NoDataType
+from semantiva.execution.fanout import expand_fanout
+from semantiva.trace.drivers.jsonl import JSONLTrace
+
+
+def test_local_fanout_runs_end_to_end(tmp_path):
+    cfg_path = Path("docs/source/examples/fanout_basic_local.yaml").resolve()
+    pipeline_cfg = load_pipeline_from_yaml(str(cfg_path))
+
+    runs, meta = expand_fanout(pipeline_cfg.fanout, cwd=cfg_path.parent)
+    assert runs, "Expected fan-out runs"
+
+    trace_dir = tmp_path / "trace"
+    trace_driver = JSONLTrace(str(trace_dir))
+    pipeline = Pipeline(
+        pipeline_cfg.nodes,
+        trace=trace_driver,
+    )
+
+    outputs = []
+    for idx, values in enumerate(runs):
+        fanout_args = {
+            "fanout.index": idx,
+            "fanout.mode": meta.get("mode", "single"),
+            "fanout.values": values,
+        }
+        if "source_file" in meta:
+            fanout_args["fanout.source_file"] = meta["source_file"]
+        if "source_sha256" in meta:
+            fanout_args["fanout.source_sha256"] = meta["source_sha256"]
+        pipeline.set_run_metadata({"args": fanout_args})
+        payload = Payload(NoDataType(), ContextType(values))
+        result = pipeline.process(payload)
+        outputs.append(result.data.data)
+
+    trace_driver.close()
+
+    expected = [vals["value"] * vals["factor"] for vals in runs]
+    assert outputs == expected
+    ser_files = list(trace_dir.glob("*.ser.jsonl"))
+    assert ser_files, "SER file not created for fan-out run"

--- a/tests/test_ser_fanout_pin.py
+++ b/tests/test_ser_fanout_pin.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from semantiva import Pipeline, Payload
+from semantiva.context_processors import ContextType
+from semantiva.data_types import NoDataType
+from semantiva.examples.test_utils import (
+    FloatMockDataSink,
+    FloatMultiplyOperation,
+    FloatValueDataSource,
+)
+from semantiva.trace.model import SERRecord, TraceDriver
+
+
+class _CaptureTrace(TraceDriver):
+    def __init__(self) -> None:
+        self.events: list[SERRecord] = []
+
+    def on_pipeline_start(
+        self, pipeline_id, run_id, canonical_spec, meta, pipeline_input=None
+    ):
+        return None
+
+    def on_node_event(self, event: SERRecord) -> None:
+        self.events.append(event)
+
+    def on_pipeline_end(self, run_id: str, summary: dict) -> None:
+        return None
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def test_ser_records_include_fanout_arguments(tmp_path):
+    trace = _CaptureTrace()
+    pipeline = Pipeline(
+        [
+            {"processor": FloatValueDataSource},
+            {"processor": FloatMultiplyOperation},
+            {
+                "processor": FloatMockDataSink,
+                "parameters": {"path": str(tmp_path / "out.txt")},
+            },
+        ],
+        trace=trace,
+    )
+
+    FANOUT_RUNS = [
+        (
+            {"value": 3.0, "factor": 2.0},
+            {"fanout.index": 0, "fanout.mode": "multi_zip"},
+        ),
+        (
+            {"value": 5.0, "factor": 4.0},
+            {"fanout.index": 1, "fanout.mode": "multi_zip"},
+        ),
+    ]
+
+    EXPECTED_VALUES = {
+        0: {"value": 3.0, "factor": 2.0},
+        1: {"value": 5.0, "factor": 4.0},
+    }
+
+    for values, base_args in FANOUT_RUNS:
+        fanout_args = dict(base_args)
+        fanout_args["fanout.values"] = values
+        pipeline.set_run_metadata({"args": fanout_args})
+        payload = Payload(NoDataType(), ContextType(values))
+        pipeline.process(payload)
+
+    assert trace.events, "expected SER events to be captured"
+    run_ids = {event.ids["run_id"] for event in trace.events}
+    assert len(run_ids) == len(FANOUT_RUNS)
+    for event in trace.events:
+        args = event.checks["why_ok"].get("args", {})
+        assert "fanout.index" in args
+        assert "fanout.mode" in args
+        assert "fanout.values" in args
+        index = args["fanout.index"]
+        assert args["fanout.values"] == EXPECTED_VALUES[index]

--- a/tests/test_yaml_schema_exec_trace_fanout.py
+++ b/tests/test_yaml_schema_exec_trace_fanout.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from semantiva.configurations import load_pipeline_from_yaml
+
+
+def test_yaml_parses_execution_trace_and_fanout(tmp_path):
+    yaml_content = """
+execution:
+  orchestrator: LocalSemantivaOrchestrator
+  executor: SequentialSemantivaExecutor
+  transport: InMemorySemantivaTransport
+  options:
+    retries: 2
+trace:
+  driver: jsonl
+  output_path: ./ser/out.ser.jsonl
+  options:
+    detail: all
+fanout:
+  multi:
+    value: [1, 2]
+    factor: [3, 4]
+pipeline:
+  nodes:
+    - processor: FloatValueDataSource
+    - processor: FloatMockDataSink
+      parameters:
+        path: ./fanout.txt
+"""
+    cfg_path = tmp_path / "schema.yaml"
+    cfg_path.write_text(yaml_content)
+
+    pipeline_cfg = load_pipeline_from_yaml(str(cfg_path))
+
+    assert pipeline_cfg.execution.orchestrator == "LocalSemantivaOrchestrator"
+    assert pipeline_cfg.execution.executor == "SequentialSemantivaExecutor"
+    assert pipeline_cfg.execution.transport == "InMemorySemantivaTransport"
+    assert pipeline_cfg.execution.options["retries"] == 2
+
+    assert pipeline_cfg.trace.driver == "jsonl"
+    assert pipeline_cfg.trace.output_path == "./ser/out.ser.jsonl"
+    assert pipeline_cfg.trace.options["detail"] == "all"
+
+    assert pipeline_cfg.fanout.multi == {"value": [1, 2], "factor": [3, 4]}
+    assert pipeline_cfg.fanout.mode == "zip"
+    assert len(pipeline_cfg.nodes) == 2


### PR DESCRIPTION
- YAML + CLI: add execution/trace/fanout blocks; options via repeatable key=value
- Orchestrator factory: resolve orchestrator/executor/transport via registry
- Fan-out v1: single-param and multi ZIP expansion; SER pins per-run args (index/mode/values, source hashing)
- ExecutionComponentRegistry: dedicated registry for orchestrators/executors/transports with lazy defaults, fixes circular imports; factory integration
- Docs: add pipeline schema page; unify registry docs into single “Registry System”; update examples and cross-refs
- README/CLI flags aligned with new schema; tests/docs updated