### PR TITLE
docs(cli,identity,contracts): align CLI flags, identity docs and SVA workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
-## [v0.5.1] - Unreleased
+## [v0.5.1] - 2025-12-07
 
 ### Added
 - Introduced :func:`semantiva.inspection.build_inspection_payload` as the
   canonical inspection payload builder with full docstrings.
 - Documented :class:`semantiva.trace.drivers.jsonl.JsonlTraceDriver` constructor
   parameters and detail flags for SER emission.
+- Enhanced :class:`semantiva.data_processors.data_processors.ParameterInfo`
+  with a custom ``__repr__`` method for cleaner semantic ID and metadata output.
 
 ### Deprecated
 - :func:`semantiva.inspection.build` now emits :class:`DeprecationWarning` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   concepts and architecture overview, and adding a minimal component dev-loop
   example while keeping showcased examples runnable from `docs/examples/`.
 - Enable code copy buttons in code blocks across the docs.
+- Removed references to the non-existent ``--run-space-override`` flag, added
+  the Identity & Trace quick map, and documented the SVA troubleshooting
+  workflow for ``semantiva dev lint``.
 
 
 ## [v0.5.0] - 2025-11-15

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -35,9 +35,15 @@ Minimal usage:
 Common options:
 
 - ``--context key=value`` - Provide initial context key/values.
-- ``--run-space-override path.yaml`` - Override the ``run_space`` block.
 - ``--dry-run`` - Build the graph without executing nodes.
 - ``--validate`` - Validate configuration only.
+
+.. note::
+
+   For multi-run launches, parameter sweeps, or reusable launch plans, define a
+   :doc:`run-space <run_space>` around your pipeline instead of relying on
+   ad-hoc overrides. You can also load a run-space definition directly with
+   ``--run-space-file`` when invoking ``semantiva run``.
 
 ``--context`` vs ``--set``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/contracts.rst
+++ b/docs/source/contracts.rst
@@ -22,6 +22,29 @@ Fixing common SVA errors
   ``suppressed_context_keys`` must be lists of unique strings without
   overlap.
 
+.. _sva-troubleshooting-workflow:
+
+SVA troubleshooting workflow
+----------------------------
+
+When :command:`semantiva dev lint` reports SVA errors:
+
+1. **Locate the SVA code** in the output (for example ``SVA220`` or ``SVA250``).
+2. **Look up the code** in the :doc:`Semantiva Contracts catalog <contracts>`
+   table above (or via your editor's search).
+3. **Read the expectation** and the suggested fix; most rules point to the
+   relevant metadata field or method (such as ``*_data_type`` or
+   ``context_key``).
+4. **Adjust your component** accordingly and re-run
+   :command:`semantiva dev lint` until all errors are resolved.
+
+For example, ``SVA220`` highlights a :class:`~semantiva.data_processors.data_processors.DataOperation`
+without both ``input_data_type`` and ``output_data_type`` defined; the fix is
+to add both class methods or metadata fields. ``SVA250`` flags illegal uses of
+a ``context`` parameter or context type in ``_process_logic``; the fix is to
+keep node signatures context-agnostic and route context via pipeline and node
+metadata instead.
+
 Probe node contract (mandatory)
 -------------------------------
 

--- a/docs/source/creating_components.rst
+++ b/docs/source/creating_components.rst
@@ -193,6 +193,9 @@ Run contract checks with the CLI:
     # Detailed diagnostics
     semantiva dev lint --modules my_package.ext --debug
 
+When linting flags SVA codes, consult :doc:`contracts` and follow the
+:ref:`sva-troubleshooting-workflow` to fix issues before shipping.
+
 
 Minimal dev loop: component in a Python pipeline
 ------------------------------------------------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -62,8 +62,12 @@ Common usage patterns:
    # Extended inspection with per-node details
    semantiva inspect pipeline.yaml --extended
 
-For full options and advanced usage, see :doc:`cli`. For detailed inspection examples
-and validation workflows, see :doc:`introspection_validation` and :doc:`pipelines_yaml`.
+The ``dev`` subcommand is primarily for framework developers; 
+:command:`semantiva dev lint` audits components against the 
+:doc:`Semantiva Contracts <contracts>` catalog. For full options 
+and advanced usage, see :doc:`cli`. For detailed inspection examples
+and validation workflows, see :doc:`introspection_validation` and 
+:doc:`pipelines_yaml`.
 
 Quickstart - Hello pipeline (YAML only)
 ---------------------------------------

--- a/docs/source/graph.rst
+++ b/docs/source/graph.rst
@@ -4,19 +4,25 @@ Canonical Graph Builder
 The :py:mod:`semantiva.pipeline.graph_builder` module normalizes a pipeline definition
 (from YAML, dictionaries or an existing ``Pipeline``)
 into a canonical :term:`GraphV1` representation. Each node receives a deterministic
-:term:`node_uuid` and the entire graph hashes to a :term:`PipelineId` using SHA-256.
+:term:`node_uuid`, and the canonical graph feeds Semantiva's identity stack
+(:ref:`identity-quick-map`).
 
 Graph and Identity
 ------------------
 
 When Semantiva loads a YAML pipeline, it is converted into a canonical ``GraphV1``.
-From this graph Semantiva derives stable identifiers:
+From this graph Semantiva derives stable identifiers used across inspection,
+run-space planning, and runtime traces (see :doc:`identity_cheatsheet`):
 
-* ``node_uuid`` - a positional identifier for each node.
-* ``PipelineId`` - a deterministic identifier for the whole pipeline.
+* ``node_uuid`` - positional identifier for each declared node.
+* ``node_semantic_id`` - captures preprocessor semantics for nodes that use
+  ``derive`` blocks (e.g., parameter sweeps).
+* **Semantic ID** (``plsemid-…``) - the pipeline meaning hash computed from the
+  canonical graph and node semantics.
 
-These identities are embedded in trace records and introspection outputs, ensuring
-that pipelines can be compared, cached, and reproduced across environments.
+Runtime identifiers such as ``plid-…`` (execution container) are derived later
+during execution; they reference the same canonical graph but are covered in
+the :doc:`identity_cheatsheet` quick map and :doc:`trace_stream_v1`.
 
 GraphV1 guarantees:
 
@@ -29,8 +35,8 @@ GraphV1 guarantees:
    To avoid identity churn, :term:`derive` blocks (e.g., ``derive.parameter_sweep``)
    are **not** hashed into the node UUID. Only the resolved processor class and the
    **effective** parameter map (after preprocessing/merging) participate. Semantic
-   changes introduced by preprocessors are tracked separately in trace metadata via
-   ``pipeline_config_id``.
+   changes introduced by preprocessors are tracked separately via
+   ``node_semantic_id`` and rolled into the pipeline Semantic ID.
 
 Example::
 

--- a/docs/source/identity_cheatsheet.rst
+++ b/docs/source/identity_cheatsheet.rst
@@ -11,6 +11,32 @@ and traceability.
    :depth: 1
 
 
+.. _identity-quick-map:
+
+Identity & Trace quick map
+--------------------------
+
+At a glance, Semantiva uses the following identity layers:
+
+- **Semantic ID** (``plsemid-…``) - "Is this the same pipeline meaning?"
+  Computed from the canonical GraphV1 structure via
+  :func:`semantiva.inspection.build_inspection_payload`.
+- **Config ID** (``plcid-…``) - "Is this the same configured instance?"
+  Derived from the canonicalized YAML configuration.
+- **Run-Space Spec ID** (``run_space_spec_id``) - "Is this the same launch
+  plan?" Computed from the run-space configuration (RSCF v1).
+- **Run-Space Launch & Attempt** (``run_space_launch_id``,
+  ``run_space_attempt``) - "Which launch container and retry attempt?"
+  Emitted in run-space lifecycle and runtime trace.
+- **Execution IDs** (``plid-…`` and ``run-…``) - "Which execution container and
+  attempt?" Emitted in SER records and trace events.
+- **Node UUID & Node Semantic ID** - "Which declared node?" and "Has this
+  node's preprocessor changed?" Derived from GraphV1 nodes and semantics.
+
+The rest of this page expands each layer and points to where it appears in
+inspection payloads, SER schemas, and trace streams.
+
+
 Identity Layers at a Glance
 ----------------------------
 

--- a/docs/source/personas/framework_developers.rst
+++ b/docs/source/personas/framework_developers.rst
@@ -171,6 +171,8 @@ accident. As a component author, you should lean on them:
 - When ``semantiva dev lint`` reports a violation:
 
   - Use the SVA code to jump into the catalog in :doc:`../contracts`.
+  - Follow the :ref:`sva-troubleshooting-workflow` to resolve the issue and
+    rerun the linter.
   - Adjust your design or metadata rather than silencing the rule.
 
 If you find yourself repeatedly fighting a contract, that is usually a sign

--- a/docs/source/run_space.rst
+++ b/docs/source/run_space.rst
@@ -59,17 +59,20 @@ Identity and traceability
 
 Each run-space has:
 
-- A **run-space configuration ID** – derived from the run-space section itself.
-- A **run-space launch ID** – derived from the configuration plus launch
+- A **run-space configuration ID** (``run_space_spec_id``) – derived from the
+  run-space section itself (RSCF v1).
+- A **run-space launch ID** (``run_space_launch_id``) and **attempt**
+  (``run_space_attempt``) – derived from the configuration plus launch
   parameters.
 
 Each expanded run has:
 
-- A **run ID** – part of the Semantic Execution Record (SER) identity block.
-- A link back to both the pipeline configuration and the run-space
+- Execution identifiers (``plid-…`` / ``run-…``) that pair the pipeline with
+  a specific execution attempt.
+- A link back to the pipeline semantic/config IDs and the run-space
   configuration.
 
-These IDs are documented in :doc:`identity_cheatsheet` and appear in:
+These IDs are documented in the :ref:`identity-quick-map` and appear in:
 
 - :doc:`ser`
 - :doc:`trace_stream_v1`

--- a/docs/source/run_space_emission.rst
+++ b/docs/source/run_space_emission.rst
@@ -4,6 +4,9 @@ Run-Space Emission (Runtime)
 Semantiva emits dedicated lifecycle records when executing pipelines as part
 of a run-space launch. The flow is fully deterministic and uses the
 identifiers defined in the :doc:`trace schemas <trace_stream_v1>`.
+For the identity vocabulary (``run_space_spec_id``, ``run_space_launch_id``,
+``run_space_attempt`` and related pipeline IDs), see the
+:ref:`identity-quick-map` in :doc:`identity_cheatsheet`.
 
 Lifecycle
 ---------

--- a/docs/source/run_space_lifecycle.rst
+++ b/docs/source/run_space_lifecycle.rst
@@ -2,6 +2,10 @@ Run-Space Lifecycle
 ===================
 
 Semantiva traces Run-Spaces as a lifecycle enclosing one or many pipeline runs.
+For the identity vocabulary used here (``run_space_spec_id``,
+``run_space_launch_id``, ``run_space_attempt`` and related pipeline IDs), see
+the :ref:`identity-quick-map` in :doc:`identity_cheatsheet` along with
+:doc:`schema_semantic_execution_record_v1`.
 
 Records
 -------

--- a/docs/source/schema_semantic_execution_record_v1.rst
+++ b/docs/source/schema_semantic_execution_record_v1.rst
@@ -17,7 +17,10 @@ shows how each field relates to runtime behavior and glossary concepts.
 
 The schema is consumed by the :term:`Trace` pipeline and emitted by the
 :term:`JsonlTraceDriver`. For a conceptual mapping between SER entries and the
-graph runtime, see :doc:`trace_graph_alignment`.
+graph runtime, see :doc:`trace_graph_alignment`. For the identity vocabulary
+used throughout the schema (``plsemid-*``, ``plcid-*``, run-space and execution
+identifiers), refer to the :ref:`identity-quick-map` in
+:doc:`identity_cheatsheet`.
 
 Loading the Schema
 ------------------

--- a/docs/source/trace_stream_v1.rst
+++ b/docs/source/trace_stream_v1.rst
@@ -19,6 +19,21 @@ Each line is a **trace record** of a specific type, e.g.:
 
 See also: :ref:`trace_aggregator_v1` for per-run and per-launch aggregation and completeness.
 
+Identity in Trace Stream v1
+---------------------------
+
+Each event carries a subset of the identity fields documented in the
+:doc:`identity_cheatsheet` and :doc:`schema_semantic_execution_record_v1`:
+
+- Run-space lifecycle events include ``run_space_spec_id``,
+  ``run_space_launch_id`` and ``run_space_attempt``.
+- Pipeline lifecycle events include the pipeline's semantic and config IDs.
+- Node-level events (SER) include ``node_uuid`` and, where relevant,
+  ``node_semantic_id``.
+
+Think of a single pipeline run as a small tree of events within the stream,
+all tied together by this shared identity vocabulary.
+
 Validation model
 ----------------
 Validation is **flat** and **compositional**:

--- a/semantiva/cli/__init__.py
+++ b/semantiva/cli/__init__.py
@@ -754,7 +754,7 @@ def _run(args: argparse.Namespace) -> int:
             "Provide values via one of:",
             "  * CLI:  --context key=value   (repeat for multiple)",
             "  * YAML: run_space.blocks[].context: {key: [values...]}",
-            "  * Override file: --run-space-override path/to/override.yaml",
+            "  * Run-space file: --run-space-file path/to/run_space.yaml",
             "",
         ]
         print("\n".join(msg), file=sys.stderr)


### PR DESCRIPTION
- Remove references to non-existent --run-space-override from CLI stderr and docs, and point users to --context and run-space configuration instead.
- Introduce an Identity & Trace quick map in identity_cheatsheet.rst and align GraphV1, SER schema, trace stream and run-space docs to that vocabulary.
- Add an SVA troubleshooting workflow to contracts.rst and wire framework developer and component authoring docs (and getting_started) to semantiva dev lint and the contracts catalog.